### PR TITLE
Refine beta diversity utilities and remove scikit-bio dependency

### DIFF
--- a/licenses/scikit-bio-BSD-3-Clause.txt
+++ b/licenses/scikit-bio-BSD-3-Clause.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2013--, scikit-bio development team.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the names scikit-bio, skbio, or biocore nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/metax/taxafunc_ploter/diversity_plot.py
+++ b/metax/taxafunc_ploter/diversity_plot.py
@@ -1,14 +1,16 @@
 import pandas as pd
-import skbio.diversity.alpha as alpha
 import matplotlib.pyplot as plt
 import seaborn as sns
 import matplotlib.ticker as ticker
 
-from skbio.diversity import beta_diversity
-from skbio.stats.ordination import pcoa
-
-
+from ..utils.lightweight_diversity import (
+    ALPHA_DIVERSITY_METRICS,
+    ace,
+    beta_diversity_to_dataframe,
+    pcoa,
+)
 from .get_distinct_colors import GetDistinctColors
+
 
 class DiversityPlot(object):
     def __init__(self, tfa):
@@ -20,8 +22,7 @@ class DiversityPlot(object):
         sns.set_theme()
         
     def ace_with_threshold(self, row):
-        ace = alpha.ace(row, self.ace_threshold)
-        return ace
+        return ace(row, self.ace_threshold)
     
     
     def plot_alpha_diversity(self, metric:str='shannon', sample_list:list=None, 
@@ -46,21 +47,9 @@ class DiversityPlot(object):
             sub_group_list = None
             sub_meta = None
             
-                  
-        metric_dict = {
-            'shannon': alpha.shannon,
-            'simpson': alpha.simpson,
-            'chao1': alpha.chao1,
-            'observed_otus': alpha.observed_otus,
-            'pielou_e': alpha.pielou_e,
-            'fisher_alpha': alpha.fisher_alpha,
-            'dominance': alpha.dominance,
-            'menhinick': alpha.menhinick,
-            'mcintosh_d': alpha.mcintosh_d,
-            'mcintosh_e': alpha.mcintosh_e,
-            'ace': self.ace_with_threshold,
-            
-        }
+        metric_dict = dict(ALPHA_DIVERSITY_METRICS)
+        metric_dict['ace'] = self.ace_with_threshold
+
         if metric not in metric_dict:
             raise ValueError(f'Invalid metric: {metric}. Please choose from: {list(metric_dict.keys())}')
         
@@ -81,6 +70,7 @@ class DiversityPlot(object):
                 # get the threshold by 20% of the minimum value
                 df2 = df[df > 0]
                 threshold = int(df2.quantile(0.2).min())
+                threshold = max(threshold, 1)
                 
                 print(f'threshold: {threshold}')
                 self.ace_threshold = threshold
@@ -209,11 +199,9 @@ class DiversityPlot(object):
             df = df[sample_list]
             df = df.T
             
-            # bc_dm = beta_diversity("braycurtis", df, df.index)
-            bc_dm = beta_diversity(metric, df, df.index)
-            distance_matrix = bc_dm.to_data_frame()
+            distance_matrix = beta_diversity_to_dataframe(metric, df)
+            pcoa_res = pcoa(distance_matrix)
 
-            pcoa_res = pcoa(bc_dm)
             if theme is not None and theme != 'Auto':
                 plt.style.use(theme) 
             else:               
@@ -226,12 +214,13 @@ class DiversityPlot(object):
                                   hue=group_list_for_hue, palette=color_palette, alpha=0.9,
                                   edgecolor='black', linewidth=0.5)
                 
-            fig.set_xlabel("PCo1 (%.2f%%)" % (pcoa_res.proportion_explained[0] * 100), fontsize=font_size)
-            fig.set_ylabel("PCo2 (%.2f%%)" % (pcoa_res.proportion_explained[1] * 100), fontsize=font_size)
+            fig.set_xlabel("PCo1 (%.2f%%)" % (pcoa_res.proportion_explained.iloc[0] * 100), fontsize=font_size)
+            fig.set_ylabel("PCo2 (%.2f%%)" % (pcoa_res.proportion_explained.iloc[1] * 100), fontsize=font_size)
             # set title
             num_legend = len(unique_groups) if sub_meta == 'None' else len(set(style_list)) + len(unique_groups)
             
-            title = f'PCoA plot of {metric} distance {title_name} (Total explained variation: {pcoa_res.proportion_explained[0] * 100 + pcoa_res.proportion_explained[1] * 100:.2f}%)'
+            total_explained = (pcoa_res.proportion_explained.iloc[0] + pcoa_res.proportion_explained.iloc[1]) * 100
+            title = f'PCoA plot of {metric} distance {title_name} (Total explained variation: {total_explained:.2f}%)'
             plt.title(title, fontsize=font_size+2, fontweight='bold')
             
             if legend_col_num != 0:
@@ -243,7 +232,7 @@ class DiversityPlot(object):
             if show_label:
                 if rename_sample:
                     sample_list = [f'{sample_id} ({self.tfa.get_group_of_a_sample(sample_id)})' for sample_id in sample_list]
-                texts = [fig.text(pcoa_res.samples.PC1[i], pcoa_res.samples.PC2[i], s=sample_list[i], size=font_size, 
+                texts = [fig.text(pcoa_res.samples.PC1.iloc[i], pcoa_res.samples.PC2.iloc[i], s=sample_list[i], size=font_size, 
                             color='black', alpha=font_transparency) for i in range(len(sample_list))]
                 if adjust_label:
                     from adjustText import adjust_text

--- a/metax/utils/lightweight_diversity.py
+++ b/metax/utils/lightweight_diversity.py
@@ -232,6 +232,8 @@ ALPHA_DIVERSITY_METRICS = {
 BETA_DIVERSITY_METRIC_ALIASES = {
     "manhattan": "cityblock",
     "cityblock": "cityblock",
+    "bray_curtis": "braycurtis",
+    "matching": "hamming",
 }
 
 BINARY_BETA_DIVERSITY_METRICS = {
@@ -252,6 +254,38 @@ def _normalize_beta_metric(metric: str) -> str:
     return BETA_DIVERSITY_METRIC_ALIASES.get(normalized, normalized)
 
 
+def _zero_aware_braycurtis(u, v) -> float:
+    """Calculate Bray-Curtis distance with explicit all-zero handling."""
+    denominator = np.abs(u + v).sum()
+    if denominator == 0:
+        return 0.0
+    return float(np.abs(u - v).sum() / denominator)
+
+
+def _zero_aware_cosine(u, v) -> float:
+    """Calculate cosine distance with explicit zero-vector handling."""
+    u_norm = np.linalg.norm(u)
+    v_norm = np.linalg.norm(v)
+    if u_norm == 0 and v_norm == 0:
+        return 0.0
+    if u_norm == 0 or v_norm == 0:
+        return 1.0
+    return float(1 - np.dot(u, v) / (u_norm * v_norm))
+
+
+def _zero_aware_correlation(u, v) -> float:
+    """Calculate correlation distance with explicit constant-vector handling."""
+    u_centered = u - np.mean(u)
+    v_centered = v - np.mean(v)
+    u_norm = np.linalg.norm(u_centered)
+    v_norm = np.linalg.norm(v_centered)
+    if u_norm == 0 and v_norm == 0:
+        return 0.0 if np.allclose(u, v) else 1.0
+    if u_norm == 0 or v_norm == 0:
+        return 1.0
+    return float(1 - np.dot(u_centered, v_centered) / (u_norm * v_norm))
+
+
 def _dice_distance(u, v) -> float:
     """Calculate Dice dissimilarity on binary vectors.
 
@@ -268,13 +302,48 @@ def _dice_distance(u, v) -> float:
     return float(1 - (2 * shared / total))
 
 
+def _zero_aware_jaccard(u, v) -> float:
+    """Calculate Jaccard dissimilarity on binary vectors with all-zero handling."""
+    u = np.asarray(u, dtype=bool)
+    v = np.asarray(v, dtype=bool)
+    union = np.logical_or(u, v).sum()
+    if union == 0:
+        return 0.0
+    shared = np.logical_and(u, v).sum()
+    return float(1 - shared / union)
+
+
+def _jensen_shannon_distance(u, v) -> float:
+    """Calculate Jensen-Shannon distance with base-2 normalization.
+
+    Empty-vs-empty comparisons return 0.0. Empty-vs-non-empty comparisons
+    return 1.0, the maximum distance under base-2 normalization.
+    """
+    u_total = u.sum()
+    v_total = v.sum()
+    if u_total == 0 and v_total == 0:
+        return 0.0
+    if u_total == 0 or v_total == 0:
+        return 1.0
+
+    p = u / u_total
+    q = v / v_total
+    m = 0.5 * (p + q)
+
+    def kl_divergence(a, b):
+        mask = a > 0
+        return np.sum(a[mask] * np.log2(a[mask] / b[mask]))
+
+    return float(np.sqrt(0.5 * kl_divergence(p, m) + 0.5 * kl_divergence(q, m)))
+
+
 def beta_diversity_to_dataframe(metric: str, data: pd.DataFrame) -> pd.DataFrame:
     """Calculate a beta-diversity distance matrix from a samples-by-features table."""
     if data.shape[0] < 2:
         raise ValueError("At least two samples are required for beta diversity.")
 
     metric = _normalize_beta_metric(metric)
-    values = data.values
+    values = data.values.astype(float, copy=False)
 
     if np.any(pd.isna(values)):
         raise ValueError("Input table for beta diversity cannot contain NaN values.")
@@ -284,10 +353,16 @@ def beta_diversity_to_dataframe(metric: str, data: pd.DataFrame) -> pd.DataFrame
     if metric in BINARY_BETA_DIVERSITY_METRICS:
         values = values > 0
 
-    if metric == "dice":
-        distances = pdist(values, metric=_dice_distance)
-    else:
-        distances = pdist(values, metric=metric)
+    custom_metrics = {
+        "braycurtis": _zero_aware_braycurtis,
+        "cosine": _zero_aware_cosine,
+        "correlation": _zero_aware_correlation,
+        "dice": _dice_distance,
+        "jaccard": _zero_aware_jaccard,
+        "jensenshannon": _jensen_shannon_distance,
+    }
+    distance_metric = custom_metrics.get(metric, metric)
+    distances = pdist(values, metric=distance_metric)
 
     matrix = squareform(distances)
     if np.any(~np.isfinite(matrix)):

--- a/metax/utils/lightweight_diversity.py
+++ b/metax/utils/lightweight_diversity.py
@@ -1,0 +1,301 @@
+"""Lightweight diversity and PCoA utilities for MetaX.
+
+Portions of this module are adapted from scikit-bio.
+
+Original project:
+    scikit-bio
+Original copyright:
+    Copyright (c) 2013--, scikit-bio development team.
+License:
+    BSD-3-Clause. See licenses/scikit-bio-BSD-3-Clause.txt.
+
+The implementation is intentionally limited to the diversity metrics and
+ordination behavior used by MetaX, so MetaX does not require scikit-bio or its
+BIOM-format runtime dependency during normal installation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from warnings import warn
+
+import numpy as np
+import pandas as pd
+from scipy.linalg import eigh
+from scipy.optimize import minimize_scalar
+from scipy.spatial.distance import pdist, squareform
+
+
+@dataclass
+class PCoAResult:
+    """Minimal PCoA result object compatible with MetaX plotting code."""
+
+    samples: pd.DataFrame
+    proportion_explained: pd.Series
+    eigvals: pd.Series
+
+
+def _validate_counts_vector(counts, cast_int: bool = False) -> np.ndarray:
+    """Validate and normalize a one-dimensional counts vector."""
+    arr = np.asarray(counts)
+    if arr.ndim != 1:
+        raise ValueError("Counts vector must be one-dimensional.")
+
+    if cast_int:
+        arr = arr.astype(int, copy=False)
+    else:
+        arr = arr.astype(float, copy=False)
+
+    if np.any(np.isnan(arr)):
+        raise ValueError("Counts vector cannot contain NaN values.")
+    if np.any(arr < 0):
+        raise ValueError("Counts vector cannot contain negative values.")
+
+    return arr[arr != 0]
+
+
+def observed_otus(counts) -> int:
+    """Calculate the number of observed features."""
+    counts = _validate_counts_vector(counts)
+    return int(counts.size)
+
+
+def shannon(counts, base: float | None = None) -> float:
+    """Calculate Shannon entropy."""
+    counts = _validate_counts_vector(counts)
+    if counts.size == 0:
+        return np.nan
+
+    freqs = counts / counts.sum()
+    entropy = -np.sum(freqs * np.log(freqs))
+    if base is not None:
+        entropy /= np.log(base)
+    return float(entropy)
+
+
+def dominance(counts, finite: bool = False) -> float:
+    """Calculate Simpson's dominance index."""
+    counts = _validate_counts_vector(counts)
+    if counts.size == 0:
+        return np.nan
+
+    total = counts.sum()
+    if finite:
+        if total <= 1:
+            return np.nan
+        return float((counts * (counts - 1)).sum() / (total * (total - 1)))
+    return float(((counts / total) ** 2).sum())
+
+
+def simpson(counts, finite: bool = False) -> float:
+    """Calculate Simpson's diversity index."""
+    value = dominance(counts, finite=finite)
+    return float(1 - value) if not np.isnan(value) else np.nan
+
+
+def pielou_e(counts) -> float:
+    """Calculate Pielou's evenness."""
+    counts = _validate_counts_vector(counts)
+    if counts.size <= 1:
+        return np.nan
+    return float(shannon(counts) / np.log(counts.size))
+
+
+def chao1(counts) -> float:
+    """Calculate the bias-corrected Chao1 richness estimator."""
+    counts = _validate_counts_vector(counts, cast_int=True)
+    observed = counts.size
+    if observed == 0:
+        return np.nan
+
+    singles = np.sum(counts == 1)
+    doubles = np.sum(counts == 2)
+    return float(observed + singles * (singles - 1) / (2 * (doubles + 1)))
+
+
+def menhinick(counts) -> float:
+    """Calculate Menhinick's richness index."""
+    counts = _validate_counts_vector(counts)
+    if counts.size == 0:
+        return np.nan
+    return float(counts.size / np.sqrt(counts.sum()))
+
+
+def mcintosh_d(counts) -> float:
+    """Calculate McIntosh dominance index."""
+    counts = _validate_counts_vector(counts)
+    if counts.size == 0:
+        return np.nan
+
+    total = counts.sum()
+    if total == 1:
+        return np.nan
+    u_value = np.sqrt((counts**2).sum())
+    return float((total - u_value) / (total - np.sqrt(total)))
+
+
+def mcintosh_e(counts) -> float:
+    """Calculate McIntosh's evenness measure."""
+    counts = _validate_counts_vector(counts)
+    if counts.size == 0:
+        return np.nan
+
+    species = counts.size
+    total = counts.sum()
+    numerator = np.sqrt((counts * counts).sum())
+    denominator = np.sqrt((total - species + 1) ** 2 + species - 1)
+    if denominator == 0:
+        return np.nan
+    return float(numerator / denominator)
+
+
+def fisher_alpha(counts) -> float:
+    """Calculate Fisher's alpha by numerical optimization."""
+    counts = _validate_counts_vector(counts, cast_int=True)
+    if counts.size == 0:
+        return 0.0
+
+    total = counts.sum()
+    species = counts.size
+    if total == species:
+        return np.inf
+
+    def objective(alpha):
+        if alpha <= 0:
+            return np.inf
+        return (alpha * np.log1p(total / alpha) - species) ** 2
+
+    with np.errstate(invalid="ignore"):
+        result = minimize_scalar(objective)
+    if not result.success:
+        raise RuntimeError("Optimizer failed to solve for Fisher's alpha.")
+    return float(result.x)
+
+
+def ace(counts, rare_threshold: int = 10) -> float:
+    """Calculate the abundance-based coverage estimator.
+
+    This implementation follows the scikit-bio ACE logic for abundance data.
+    """
+    counts = _validate_counts_vector(counts, cast_int=True)
+    if counts.size == 0:
+        return np.nan
+    if rare_threshold < 1:
+        raise ValueError("rare_threshold must be at least 1.")
+
+    freq_counts = np.bincount(counts)
+    if len(freq_counts) <= 1:
+        return np.nan
+
+    singles = freq_counts[1] if len(freq_counts) > 1 else 0
+    rare_freqs = freq_counts[1 : rare_threshold + 1]
+    abundant_freqs = freq_counts[rare_threshold + 1 :]
+
+    rare_species = rare_freqs.sum()
+    abundant_species = abundant_freqs.sum()
+    rare_individuals = sum(i * rare_freqs[i - 1] for i in range(1, len(rare_freqs) + 1))
+
+    if rare_species == 0:
+        return float(abundant_species)
+    if rare_individuals == 0:
+        return float(abundant_species)
+    if rare_individuals == singles:
+        return np.nan
+
+    coverage = 1 - singles / rare_individuals
+    if coverage <= 0:
+        return np.nan
+
+    numerator = rare_species * sum(
+        i * (i - 1) * rare_freqs[i - 1] for i in range(1, len(rare_freqs) + 1)
+    )
+    denominator = coverage * rare_individuals * (rare_individuals - 1)
+    gamma = max(numerator / denominator - 1, 0) if denominator != 0 else 0
+
+    return float(abundant_species + rare_species / coverage + singles / coverage * gamma)
+
+
+ALPHA_DIVERSITY_METRICS = {
+    "shannon": shannon,
+    "simpson": simpson,
+    "chao1": chao1,
+    "observed_otus": observed_otus,
+    "pielou_e": pielou_e,
+    "fisher_alpha": fisher_alpha,
+    "dominance": dominance,
+    "menhinick": menhinick,
+    "mcintosh_d": mcintosh_d,
+    "mcintosh_e": mcintosh_e,
+    "ace": ace,
+}
+
+
+def beta_diversity_to_dataframe(metric: str, data: pd.DataFrame) -> pd.DataFrame:
+    """Calculate a beta-diversity distance matrix from a samples-by-features table."""
+    if data.shape[0] < 2:
+        raise ValueError("At least two samples are required for beta diversity.")
+
+    distances = pdist(data.values, metric=metric)
+    matrix = squareform(distances)
+    return pd.DataFrame(matrix, index=data.index, columns=data.index)
+
+
+def center_distance_matrix(distance_matrix: np.ndarray) -> np.ndarray:
+    """Gower-center a distance matrix for PCoA."""
+    matrix = np.asarray(distance_matrix, dtype=float)
+    e_matrix = matrix * matrix / -2.0
+    row_means = e_matrix.mean(axis=1, keepdims=True)
+    col_means = e_matrix.mean(axis=0, keepdims=True)
+    matrix_mean = e_matrix.mean()
+    return e_matrix - row_means - col_means + matrix_mean
+
+
+def pcoa(distance_matrix: pd.DataFrame | np.ndarray, warn_neg_eigval: float | bool = 0.01) -> PCoAResult:
+    """Perform principal coordinate analysis on a distance matrix."""
+    if isinstance(distance_matrix, pd.DataFrame):
+        ids = list(distance_matrix.index)
+        matrix = distance_matrix.values
+    else:
+        matrix = np.asarray(distance_matrix, dtype=float)
+        ids = [str(i) for i in range(matrix.shape[0])]
+
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("PCoA requires a square distance matrix.")
+    if not np.allclose(matrix, matrix.T):
+        raise ValueError("PCoA requires a symmetric distance matrix.")
+
+    centered = center_distance_matrix(matrix)
+    eigvals, eigvecs = eigh(centered)
+
+    eigvals = np.where(np.isclose(eigvals, 0), 0, eigvals)
+    order = np.argsort(eigvals)[::-1]
+    eigvals = eigvals[order]
+    eigvecs = eigvecs[:, order]
+
+    if warn_neg_eigval and eigvals[-1] < 0:
+        threshold = 0 if warn_neg_eigval is True else eigvals[0] * float(warn_neg_eigval)
+        if -eigvals[-1] > threshold:
+            warn(
+                "The PCoA result contains large negative eigenvalues, which may "
+                "suggest result inaccuracy for this distance matrix.",
+                RuntimeWarning,
+            )
+
+    positive_mask = eigvals >= 0
+    eigvals = np.where(positive_mask, eigvals, 0)
+    eigvecs = eigvecs * positive_mask
+
+    total = eigvals.sum()
+    if total == 0:
+        proportions = np.zeros_like(eigvals)
+    else:
+        proportions = eigvals / total
+
+    coordinates = eigvecs * np.sqrt(eigvals)
+    axis_labels = [f"PC{i}" for i in range(1, len(eigvals) + 1)]
+
+    return PCoAResult(
+        samples=pd.DataFrame(coordinates, index=ids, columns=axis_labels),
+        proportion_explained=pd.Series(proportions, index=axis_labels),
+        eigvals=pd.Series(eigvals, index=axis_labels),
+    )

--- a/metax/utils/lightweight_diversity.py
+++ b/metax/utils/lightweight_diversity.py
@@ -229,14 +229,70 @@ ALPHA_DIVERSITY_METRICS = {
     "ace": ace,
 }
 
+BETA_DIVERSITY_METRIC_ALIASES = {
+    "manhattan": "cityblock",
+    "cityblock": "cityblock",
+}
+
+BINARY_BETA_DIVERSITY_METRICS = {
+    "dice",
+    "hamming",
+    "jaccard",
+    "rogerstanimoto",
+    "russellrao",
+    "sokalmichener",
+    "sokalsneath",
+    "yule",
+}
+
+
+def _normalize_beta_metric(metric: str) -> str:
+    """Normalize user-facing metric names to SciPy-compatible names."""
+    normalized = metric.strip().lower().replace(" ", "_").replace("-", "_")
+    return BETA_DIVERSITY_METRIC_ALIASES.get(normalized, normalized)
+
+
+def _dice_distance(u, v) -> float:
+    """Calculate Dice dissimilarity on binary vectors.
+
+    Two all-zero vectors are treated as identical and return 0.0. This avoids
+    NaN values in the distance matrix and matches the expected behavior for
+    absence-only comparisons in MetaX plots.
+    """
+    u = np.asarray(u, dtype=bool)
+    v = np.asarray(v, dtype=bool)
+    shared = np.logical_and(u, v).sum()
+    total = u.sum() + v.sum()
+    if total == 0:
+        return 0.0
+    return float(1 - (2 * shared / total))
+
 
 def beta_diversity_to_dataframe(metric: str, data: pd.DataFrame) -> pd.DataFrame:
     """Calculate a beta-diversity distance matrix from a samples-by-features table."""
     if data.shape[0] < 2:
         raise ValueError("At least two samples are required for beta diversity.")
 
-    distances = pdist(data.values, metric=metric)
+    metric = _normalize_beta_metric(metric)
+    values = data.values
+
+    if np.any(pd.isna(values)):
+        raise ValueError("Input table for beta diversity cannot contain NaN values.")
+    if np.any(values < 0):
+        raise ValueError("Input table for beta diversity cannot contain negative values.")
+
+    if metric in BINARY_BETA_DIVERSITY_METRICS:
+        values = values > 0
+
+    if metric == "dice":
+        distances = pdist(values, metric=_dice_distance)
+    else:
+        distances = pdist(values, metric=metric)
+
     matrix = squareform(distances)
+    if np.any(~np.isfinite(matrix)):
+        raise ValueError(f"Metric '{metric}' produced non-finite distances and cannot be plotted.")
+
     return pd.DataFrame(matrix, index=data.index, columns=data.index)
 
 
@@ -263,6 +319,8 @@ def pcoa(distance_matrix: pd.DataFrame | np.ndarray, warn_neg_eigval: float | bo
         raise ValueError("PCoA requires a square distance matrix.")
     if not np.allclose(matrix, matrix.T):
         raise ValueError("PCoA requires a symmetric distance matrix.")
+    if np.any(~np.isfinite(matrix)):
+        raise ValueError("PCoA requires a finite distance matrix.")
 
     centered = center_distance_matrix(matrix)
     eigvals, eigvecs = eigh(centered)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "scikit-learn>=1.3.0",
     "scipy>=1.11.3",
     "tqdm>=4.65.0",
-    "scikit-bio>=0.6.3",
     "adjustText>=1.1.1",
     "openpyxl",
     "pyproject-toml>=0.0.10",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ QtAwesome>=1.2.3
 scikit-learn>=1.3.0
 scipy>=1.11.3
 tqdm>=4.65.0
-scikit-bio>=0.6.3
 adjustText>=1.1.1
 openpyxl
 pyproject-toml>=0.0.10


### PR DESCRIPTION
This pull request refactors the diversity plotting functionality to remove the direct dependency on the `scikit-bio` package and instead use a new lightweight internal implementation for diversity calculations. It also adds the appropriate license for scikit-bio and makes minor improvements to the plotting logic.

Dependency and Licensing Updates:
* Removed the `scikit-bio` dependency from `pyproject.toml`, and added the `scikit-bio-BSD-3-Clause.txt` license file to comply with licensing requirements for code or logic derived from scikit-bio. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L39) [[2]](diffhunk://#diff-65631aa2e840650f4251442a9752c31d1e5846a4c9bebb7951d044a6ea8eb4bcR1-R27)

Refactoring to Use Internal Diversity Functions:
* Replaced all imports and usages of `skbio.diversity` and related modules in `diversity_plot.py` with imports from the new internal `lightweight_diversity` module, including alpha and beta diversity metrics, and PCoA. [[1]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952L2-R14) [[2]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952L23-R25) [[3]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952R50-L63) [[4]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952L212-L216)

Code and Plotting Improvements:
* Updated references to pandas Series/Index access in PCoA result handling to use `.iloc` for compatibility with the new data structures returned by the internal implementation. [[1]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952L229-R223) [[2]](diffhunk://#diff-13406885d184ad67c67bb6405962dbed27a1aedc1ddf9548e4dfa95f2093d952L246-R235)
* Improved the ACE threshold calculation in alpha diversity plotting to ensure the threshold is always at least 1, making the calculation more robust.