### PR TITLE
Add HTML report CLI workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ build
 venv
 *.egg-info
 conda-recipe
+report_output*/

--- a/metax/report/__init__.py
+++ b/metax/report/__init__.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+from pathlib import Path
+
+_mpl_config_dir = Path(tempfile.gettempdir()) / "metax_matplotlib"
+_mpl_config_dir.mkdir(parents=True, exist_ok=True)
+os.environ["MPLCONFIGDIR"] = str(_mpl_config_dir)
+
+from .config import (
+    AnalysisConfig,
+    AutoReportConfig,
+    HtmlReportConfig,
+    InputConfig,
+    PlotConfig,
+    PreprocessConfig,
+    StatsConfig,
+    TableConfig,
+    load_config_from_yaml,
+    save_config_to_yaml,
+)
+from .workflow import AutoOTFReport, ReportResult
+
+__all__ = [
+    "AnalysisConfig",
+    "AutoOTFReport",
+    "AutoReportConfig",
+    "HtmlReportConfig",
+    "InputConfig",
+    "PlotConfig",
+    "PreprocessConfig",
+    "ReportResult",
+    "StatsConfig",
+    "TableConfig",
+    "load_config_from_yaml",
+    "save_config_to_yaml",
+]

--- a/metax/report/cli.py
+++ b/metax/report/cli.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .config import AutoReportConfig, load_config_from_yaml
+from .workflow import AutoOTFReport
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate a MetaX Auto OTF HTML report.")
+    parser.add_argument("--otf", help="Path to the OTF table.")
+    parser.add_argument("--out", help="Output report directory.")
+    parser.add_argument("--meta", help="Path to the metadata table.")
+    parser.add_argument("--group", help="Metadata column used for grouping.")
+    parser.add_argument("--control", help="Control group inside the grouping column.")
+    parser.add_argument("--taxa-levels", help="Comma-separated taxa levels, e.g. p,g,s or all.")
+    parser.add_argument("--func", help="Comma-separated function annotation columns, or auto.")
+    parser.add_argument("--config", help="YAML configuration file.")
+    parser.add_argument("--sample-col-prefix", help="Sample intensity column prefix.")
+    parser.add_argument("--peptide-col-name", help="Peptide column name.")
+    parser.add_argument("--protein-col-name", help="Protein column name.")
+    parser.add_argument("--top-n", type=int, help="Top-N value for report plots.")
+    parser.add_argument("--run-deseq2", action="store_true", default=None, help="Request optional DESeq2-like analysis.")
+    parser.add_argument("--no-diversity", action="store_true", default=None, help="Disable diversity plots.")
+    parser.add_argument("--run-network", action="store_true", default=None, help="Enable heavy taxa-function network plots.")
+    parser.add_argument("--no-network", action="store_true", default=None, help="Disable network plots.")
+    parser.add_argument("--overwrite", action="store_true", default=None, help="Allow writing into an existing output directory.")
+    return parser
+
+
+def config_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> AutoReportConfig:
+    if args.config:
+        config = load_config_from_yaml(args.config)
+    else:
+        config = AutoReportConfig()
+
+    if args.otf is not None:
+        config.input.otf_path = args.otf
+    if args.meta is not None:
+        config.input.meta_path = args.meta
+    if args.out is not None:
+        config.report.output_dir = args.out
+    if args.group is not None:
+        config.analysis.group_meta = args.group
+    if args.control is not None:
+        config.analysis.control_group = args.control
+    if args.taxa_levels is not None:
+        config.tables.taxa_levels = _split_csv(args.taxa_levels)
+    if args.func is not None:
+        config.tables.function_columns = "auto" if args.func == "auto" else _split_csv(args.func)
+    if args.sample_col_prefix is not None:
+        config.input.sample_col_prefix = args.sample_col_prefix
+    if args.peptide_col_name is not None:
+        config.input.peptide_col_name = args.peptide_col_name
+    if args.protein_col_name is not None:
+        config.input.protein_col_name = args.protein_col_name
+    if args.top_n is not None:
+        config.plots.top_n = args.top_n
+    if args.run_deseq2:
+        config.statistics.run_deseq2 = True
+    if args.no_diversity:
+        config.plots.run_diversity = False
+        config.plots.run_alpha_diversity = False
+        config.plots.run_beta_diversity = False
+    if args.run_network:
+        config.plots.run_network = True
+    if args.no_network:
+        config.plots.run_network = False
+    if args.overwrite:
+        config.report.overwrite = True
+
+    if not args.config and not config.input.otf_path:
+        parser.error("--otf is required unless --config is provided.")
+    if not args.config and not args.out:
+        parser.error("--out is required unless --config is provided.")
+    if not config.input.otf_path:
+        parser.error("Config does not define input.otf_path and --otf was not provided.")
+    return config
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        config = config_from_args(args, parser)
+        result = AutoOTFReport(config).run()
+        print(Path(result.index_html_path))
+        return 0
+    except Exception as exc:
+        print(f"metax-report failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def _split_csv(value: str) -> list[str]:
+    if value.lower() == "all":
+        return ["all"]
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/metax/report/config.py
+++ b/metax/report/config.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, fields
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import yaml
+
+
+@dataclass
+class InputConfig:
+    otf_path: str = ""
+    meta_path: Optional[str] = None
+    peptide_col_name: str = "Sequence"
+    protein_col_name: str = "Proteins"
+    sample_col_prefix: str = "Intensity"
+    any_df_mode: bool = False
+    custom_col_name: Optional[str] = None
+
+
+@dataclass
+class AnalysisConfig:
+    group_meta: Optional[str] = None
+    control_group: Optional[str] = None
+    condition_meta: Optional[str] = None
+    main_taxa_level: str = "s"
+    main_function: Optional[str] = None
+
+
+@dataclass
+class PreprocessConfig:
+    quant_method: str = "sum"
+    outlier_detect_method: str = "missing-value"
+    outlier_handle_method: str = "fillzero"
+    detection_by_group: Optional[str] = None
+    handle_by_group: Optional[str] = None
+    normalize_method: str = "None"
+    transform_method: str = "None"
+    batch_meta: Optional[str] = None
+    taxa_peptide_num_threshold: int = 3
+    func_peptide_num_threshold: int = 3
+    otf_peptide_num_threshold: int = 3
+
+
+@dataclass
+class TableConfig:
+    taxa_levels: list[str] = field(default_factory=lambda: ["p", "g", "s"])
+    function_columns: Union[str, list[str]] = "auto"
+    generate_taxa_tables: bool = True
+    generate_function_tables: bool = True
+    generate_otf_tables: bool = True
+    generate_protein_table: bool = False
+    split_func: bool = False
+    split_by: str = "|"
+    keep_unknown_func: bool = False
+    share_intensity: bool = False
+
+    def __post_init__(self) -> None:
+        if isinstance(self.taxa_levels, str):
+            self.taxa_levels = _split_csv(self.taxa_levels)
+        if isinstance(self.function_columns, str) and self.function_columns != "auto":
+            self.function_columns = _split_csv(self.function_columns)
+
+
+@dataclass
+class StatsConfig:
+    run_anova: bool = True
+    run_ttest: bool = True
+    run_group_vs_control: bool = True
+    diff_method: str = "dunnett"
+    p_adjust_method: str = "fdr_bh"
+    alpha: float = 0.05
+    log2fc_cutoff: float = 1.0
+    pseudo_count: float = 1.0
+    min_prevalence: float = 0.1
+    run_deseq2: bool = False
+
+
+@dataclass
+class PlotConfig:
+    top_n: int = 20
+    heatmap_top_n: int = 50
+    network_top_n: int = 50
+    run_overview: bool = True
+    run_pca: bool = True
+    run_pca_3d: bool = False
+    run_tsne: bool = False
+    run_correlation: bool = True
+    run_heatmap: bool = True
+    run_box: bool = True
+    run_bar: bool = True
+    run_barplot: bool = True
+    run_upset: bool = False
+    run_alpha_diversity: bool = True
+    run_beta_diversity: bool = True
+    run_diversity: bool = True
+    run_volcano: bool = True
+    run_sankey: bool = True
+    run_sunburst: bool = True
+    run_treemap: bool = True
+    run_network: bool = False
+
+
+@dataclass
+class HtmlReportConfig:
+    title: str = "MetaX Auto Report"
+    output_dir: str = "report_output"
+    embed_interactive_html: bool = False
+    show_top_rows: int = 20
+    copy_static_assets: bool = True
+    overwrite: bool = False
+
+
+@dataclass
+class AutoReportConfig:
+    input: InputConfig = field(default_factory=InputConfig)
+    analysis: AnalysisConfig = field(default_factory=AnalysisConfig)
+    preprocessing: PreprocessConfig = field(default_factory=PreprocessConfig)
+    tables: TableConfig = field(default_factory=TableConfig)
+    statistics: StatsConfig = field(default_factory=StatsConfig)
+    plots: PlotConfig = field(default_factory=PlotConfig)
+    report: HtmlReportConfig = field(default_factory=HtmlReportConfig)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "AutoReportConfig":
+        data = data or {}
+        return cls(
+            input=_dataclass_from_dict(InputConfig, data.get("input", {})),
+            analysis=_dataclass_from_dict(AnalysisConfig, data.get("analysis", {})),
+            preprocessing=_dataclass_from_dict(PreprocessConfig, data.get("preprocessing", {})),
+            tables=_dataclass_from_dict(TableConfig, data.get("tables", {})),
+            statistics=_dataclass_from_dict(StatsConfig, data.get("statistics", {})),
+            plots=_dataclass_from_dict(PlotConfig, data.get("plots", {})),
+            report=_dataclass_from_dict(HtmlReportConfig, data.get("report", {})),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_config_from_yaml(path: str | Path) -> AutoReportConfig:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML config must contain a mapping at the top level: {config_path}")
+    return AutoReportConfig.from_dict(data)
+
+
+def save_config_to_yaml(config: AutoReportConfig, path: str | Path) -> None:
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(config.to_dict(), handle, sort_keys=False, allow_unicode=False)
+
+
+def save_config_used(config: AutoReportConfig, output_dir: str | Path) -> None:
+    save_config_to_yaml(config, Path(output_dir) / "config_used.yaml")
+
+
+def _dataclass_from_dict(cls: type, data: dict[str, Any] | None):
+    data = data or {}
+    valid_fields = {item.name for item in fields(cls)}
+    kwargs = {key: value for key, value in data.items() if key in valid_fields}
+    return cls(**kwargs)
+
+
+def _split_csv(value: str) -> list[str]:
+    if value.lower() == "all":
+        return ["all"]
+    return [item.strip() for item in value.split(",") if item.strip()]

--- a/metax/report/html_report.py
+++ b/metax/report/html_report.py
@@ -1,0 +1,607 @@
+from __future__ import annotations
+
+import os
+import re
+import shutil
+from html import escape
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+import yaml
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+if TYPE_CHECKING:
+    from .workflow import ReportContext
+
+
+class HtmlReportBuilder:
+    def __init__(self, context: "ReportContext"):
+        self.context = context
+        template_dir = Path(__file__).parent / "templates"
+        self.env = Environment(
+            loader=FileSystemLoader(template_dir),
+            autoescape=select_autoescape(["html", "xml"]),
+        )
+
+    def render(self) -> Path:
+        output_path = self.context.paths.output_dir / "index.html"
+        template = self.env.get_template("report.html.j2")
+        html = template.render(**self._template_context())
+        output_path.write_text(html, encoding="utf-8")
+        self.context.registry.add_html(
+            "index_html",
+            output_path,
+            title="HTML report",
+            description="Final MetaX Auto OTF report.",
+        )
+        self.context.logger.info("Rendered HTML report: %s", output_path)
+        return output_path
+
+    def _template_context(self) -> dict[str, Any]:
+        registry = self.context.registry.to_dict()
+        tables = [self._artifact(item) for item in registry["tables"]]
+        stats = [self._artifact(item) for item in registry["stats"]]
+        figures = [self._artifact(item) for item in registry["figures"]]
+        html_items = [self._artifact(item) for item in registry["html"]]
+        self._attach_result_table_links(figures, tables + stats)
+        figures_by_kind = self._group_figures_by_kind(figures)
+        basic_plot_subgroups = {
+            kind: self._group_basic_figures_by_scope(items)
+            for kind, items in figures_by_kind.items()
+        }
+        basic_plot_otf_function_groups = {
+            kind: self._group_basic_otf_figures_by_function(items)
+            for kind, items in figures_by_kind.items()
+        }
+        result_files_by_category = self._result_files_by_category(tables, stats)
+        differential_figures = [item for item in figures if item.get("category") == "differential"]
+
+        return {
+            "title": self.context.config.report.title,
+            "config": self.context.config.to_dict(),
+            "config_yaml": yaml.safe_dump(self.context.config.to_dict(), sort_keys=False, allow_unicode=False),
+            "dataset_summary": self.context.dataset_summary,
+            "run_summary": self._run_summary(tables, stats, figures),
+            "tables": tables,
+            "tables_by_category": self._group_by_category(tables),
+            "result_files": tables + stats,
+            "result_files_by_category": result_files_by_category,
+            "result_file_count": sum(len(items) for items in result_files_by_category.values()),
+            "stats": stats,
+            "figures": figures,
+            "figures_by_category": self._group_by_category(figures),
+            "overview_figures_by_group": self._group_overview_figures(
+                [item for item in figures if item.get("category") == "overview"]
+            ),
+            "figures_by_kind": figures_by_kind,
+            "basic_plot_subgroups": basic_plot_subgroups,
+            "basic_plot_otf_function_groups": basic_plot_otf_function_groups,
+            "basic_plot_figure_count": sum(len(items) for items in figures_by_kind.values()),
+            "basic_plot_family_notes": _basic_plot_family_notes(),
+            "differential_figures_by_scope": self._group_differential_figures(differential_figures),
+            "html_items": html_items,
+            "warnings": registry["warnings"],
+            "errors": registry["errors"],
+            "warning_run_info": self._warning_run_info(),
+            "runtime": registry["runtime"],
+            "embed_interactive_html": self.context.config.report.embed_interactive_html,
+            "selected_taxa_levels": self.context.taxa_levels,
+            "selected_function_columns": self.context.function_columns,
+            "favicon_path": self._copy_report_icon(),
+        }
+
+    def _run_summary(self, tables: list[dict[str, Any]], stats: list[dict[str, Any]], figures: list[dict[str, Any]]) -> dict[str, Any]:
+        config = self.context.config
+        return {
+            "otf_file": config.input.otf_path,
+            "meta_file": config.input.meta_path or "Generated internally",
+            "n_samples": self.context.dataset_summary.get("n_samples", 0),
+            "n_groups": self.context.dataset_summary.get("n_groups", 0),
+            "group_column": config.analysis.group_meta or "None",
+            "control_group": config.analysis.control_group or "None",
+            "main_taxa_level": config.analysis.main_taxa_level,
+            "main_function": config.analysis.main_function or "auto",
+            "n_tables": len(tables),
+            "n_stats": len(stats),
+            "n_figures": len(figures),
+            "n_warnings": len(self.context.registry.warnings),
+        }
+
+    def _warning_run_info(self) -> dict[str, Any]:
+        config = self.context.config
+        return {
+            "group_meta": config.analysis.group_meta or "None",
+            "control_group": config.analysis.control_group or "None",
+            "taxa_levels": ", ".join(self.context.taxa_levels) or "None",
+            "function_columns": ", ".join(self.context.function_columns) or "None",
+            "top_n": config.plots.top_n,
+            "heatmap_top_n": config.plots.heatmap_top_n,
+            "alpha": config.statistics.alpha,
+            "log2fc_cutoff": config.statistics.log2fc_cutoff,
+            "pseudo_count": config.statistics.pseudo_count,
+        }
+
+    def _artifact(self, item: dict[str, Any]) -> dict[str, Any]:
+        artifact = dict(item)
+        path = Path(str(item["path"]))
+        artifact["relative_path"] = self._relative_path(path)
+        artifact["category"] = self._category(path)
+        artifact["rich_title"] = self._rich_title(str(artifact.get("title", artifact.get("key", ""))))
+        alternate_path = artifact.get("alternate_interactive_path")
+        if alternate_path:
+            alternate = Path(str(alternate_path))
+            artifact["alternate_interactive_relative_path"] = self._relative_path(alternate)
+        if path.suffix.lower() in {".tsv", ".csv"} and path.exists():
+            preview_path = self._write_table_preview(path, item["key"])
+            if preview_path:
+                artifact["preview_relative_path"] = self._relative_path(preview_path)
+        return artifact
+
+    def _copy_report_icon(self) -> str | None:
+        source = Path(__file__).resolve().parents[1] / "gui" / "metax_gui" / "resources" / "logo.png"
+        if not source.exists():
+            self.context.registry.add_warning(
+                f"Report icon was not found: {source}",
+                source="html_report",
+            )
+            return None
+        try:
+            destination = self.context.paths.assets_dir / "logo.png"
+            shutil.copyfile(source, destination)
+            return self._relative_path(destination)
+        except Exception as exc:
+            self.context.registry.add_warning(
+                f"Could not copy report icon: {exc}",
+                source="html_report",
+            )
+            return None
+
+    def _attach_result_table_links(
+        self,
+        figures: list[dict[str, Any]],
+        result_files: list[dict[str, Any]],
+    ) -> None:
+        result_by_key = {str(item.get("key", "")): item for item in result_files}
+        for figure in figures:
+            result = self._matching_result_file(figure, result_by_key)
+            if not result:
+                continue
+            figure["table_title"] = result.get("title") or result.get("key", "Result table")
+            figure["table_relative_path"] = result.get("relative_path")
+            if result.get("preview_relative_path"):
+                figure["table_preview_relative_path"] = result["preview_relative_path"]
+
+    def _matching_result_file(
+        self,
+        figure: dict[str, Any],
+        result_by_key: dict[str, dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        key = str(figure.get("key", ""))
+        candidates: list[str] = []
+
+        prefix_map = [
+            "pca_3d_",
+            "pca_",
+            "tsne_",
+            "sample_correlation_",
+            "top_feature_heatmap_",
+            "boxplot_",
+            "bar_",
+            "upset_",
+            "alpha_diversity_",
+            "beta_diversity_",
+            "treemap_",
+            "sunburst_",
+            "sankey_",
+            "differential_heatmap_",
+            "dunnett_heatmap_",
+            "volcano_",
+            "deseq2_sankey_",
+        ]
+        for prefix in prefix_map:
+            if key.startswith(prefix):
+                candidates.append(key[len(prefix):])
+                break
+
+        if key in {"taxa_stats_pie", "taxa_number_bar"}:
+            main_key = f"taxa_{self.context.config.analysis.main_taxa_level}"
+            candidates.extend([main_key, *[item for item in result_by_key if item.startswith("taxa_") and "_" not in item[5:]]])
+        elif key.startswith("function_proportion_"):
+            candidates.append(f"function_{key.removeprefix('function_proportion_')}")
+
+        for candidate in candidates:
+            if candidate in result_by_key:
+                return result_by_key[candidate]
+
+        for result_key in sorted(result_by_key, key=len, reverse=True):
+            if result_key and (key.endswith(result_key) or f"_{result_key}_" in f"_{key}_"):
+                return result_by_key[result_key]
+        return None
+
+    def _write_table_preview(self, path: Path, key: str) -> Path | None:
+        sep = "\t" if path.suffix.lower() == ".tsv" else ","
+        try:
+            df = pd.read_csv(path, sep=sep, nrows=max(self.context.config.report.show_top_rows, 500))
+            preview_dir = self.context.paths.assets_dir / "previews"
+            preview_dir.mkdir(parents=True, exist_ok=True)
+            preview_path = preview_dir / f"{_safe_filename(key)}.html"
+            if df.empty:
+                body = "<p class=\"muted\">No rows in this file.</p>"
+            else:
+                body = df.to_html(index=False, classes="preview-table", border=0, escape=True, table_id="preview-table")
+            preview_path.write_text(
+                self._preview_document(path, body),
+                encoding="utf-8",
+            )
+            return preview_path
+        except Exception as exc:
+            self.context.logger.warning("Could not preview table %s: %s", path, exc)
+            return None
+
+    def _preview_document(self, source_path: Path, body: str) -> str:
+        page_size = self.context.config.report.show_top_rows
+        title = escape(source_path.name)
+        return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <style>
+    body {{ margin: 0; font: 12px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1f2933; }}
+    .preview-meta {{ position: sticky; top: 0; z-index: 2; display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; background: #edf3f7; border-bottom: 1px solid #d8dee8; }}
+    .pager {{ display: flex; align-items: center; gap: 7px; white-space: nowrap; }}
+    .pager button {{ border: 1px solid #cbd5e1; background: #fff; border-radius: 6px; padding: 3px 8px; cursor: pointer; }}
+    .pager button:disabled {{ opacity: .45; cursor: default; }}
+    .muted {{ color: #687584; }}
+    table.preview-table {{ width: 100%; border-collapse: collapse; background: #fff; }}
+    .preview-table th, .preview-table td {{ border-bottom: 1px solid #e8edf3; padding: 6px 8px; text-align: left; white-space: nowrap; }}
+    .preview-table th {{ position: sticky; top: 37px; background: #f7f9fc; z-index: 1; }}
+  </style>
+</head>
+<body>
+  <div class="preview-meta">
+    <div><strong>{title}</strong> <span class="muted">preview rows</span></div>
+    <div class="pager">
+      <button id="prev-page" type="button">Prev</button>
+      <span id="page-status"></span>
+      <button id="next-page" type="button">Next</button>
+    </div>
+  </div>
+  {body}
+  <script>
+    const pageSize = {page_size};
+    const rows = Array.from(document.querySelectorAll("#preview-table tbody tr"));
+    const prev = document.getElementById("prev-page");
+    const next = document.getElementById("next-page");
+    const status = document.getElementById("page-status");
+    let page = 0;
+    const totalPages = Math.max(1, Math.ceil(rows.length / pageSize));
+    function renderPage() {{
+      rows.forEach((row, index) => {{
+        row.style.display = index >= page * pageSize && index < (page + 1) * pageSize ? "" : "none";
+      }});
+      status.textContent = `${{page + 1}} / ${{totalPages}}`;
+      prev.disabled = page === 0;
+      next.disabled = page >= totalPages - 1;
+    }}
+    prev.addEventListener("click", () => {{ if (page > 0) {{ page -= 1; renderPage(); }} }});
+    next.addEventListener("click", () => {{ if (page < totalPages - 1) {{ page += 1; renderPage(); }} }});
+    renderPage();
+  </script>
+</body>
+</html>"""
+
+    def _relative_path(self, path: Path) -> str:
+        try:
+            return os.path.relpath(path.resolve(), self.context.paths.output_dir.resolve())
+        except Exception:
+            return str(path)
+
+    def _category(self, path: Path) -> str:
+        parts = list(path.parts)
+        for marker in ["tables", "stats", "figures"]:
+            if marker in parts:
+                index = parts.index(marker)
+                if len(parts) > index + 1:
+                    return parts[index + 1]
+        return "other"
+
+    def _group_by_category(self, artifacts: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for artifact in artifacts:
+            grouped.setdefault(artifact["category"], []).append(artifact)
+        return grouped
+
+    def _result_files_by_category(
+        self,
+        tables: list[dict[str, Any]],
+        stats: list[dict[str, Any]],
+    ) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for table in tables:
+            grouped.setdefault(table["category"], []).append(table)
+        for stat in stats:
+            category = f"comparison_{stat.get('category', 'other')}"
+            grouped.setdefault(category, []).append(stat)
+        return grouped
+
+    def _group_overview_figures(self, figures: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        grouped = {
+            "Taxonomy and dataset coverage": [],
+            "Function annotation coverage": [],
+        }
+        for figure in figures:
+            key = str(figure.get("key", ""))
+            if key.startswith("function_proportion_"):
+                grouped["Function annotation coverage"].append(figure)
+            else:
+                grouped["Taxonomy and dataset coverage"].append(figure)
+        return {name: items for name, items in grouped.items() if items}
+
+    def _group_figures_by_kind(self, figures: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        labels = {
+            "pca": "PCA",
+            "pca_3d": "3D PCA",
+            "tsne": "t-SNE",
+            "correlation": "Correlation Heatmap",
+            "heatmap": "Heatmap",
+            "box": "Box",
+            "bar": "Bar",
+            "upset": "UpSet",
+            "alpha_diversity": "Alpha Diversity",
+            "beta_diversity": "Beta Diversity",
+            "treemap": "TreeMap",
+            "sunburst": "Sunburst",
+            "sankey": "Sankey",
+            "differential": "Differential",
+            "taxa_function": "Taxa-function links",
+            "other": "Other figures",
+        }
+        for figure in figures:
+            if figure.get("category") not in {"basic", "composition"}:
+                continue
+            key = str(figure.get("key", ""))
+            if key.startswith("pca_3d_"):
+                kind = "pca_3d"
+            elif key.startswith("pca_"):
+                kind = "pca"
+            elif key.startswith("tsne_"):
+                kind = "tsne"
+            elif key.startswith("sample_correlation_"):
+                kind = "correlation"
+            elif key.startswith("top_feature_heatmap_"):
+                kind = "heatmap"
+            elif key.startswith("boxplot_"):
+                kind = "box"
+            elif key.startswith("bar_"):
+                kind = "bar"
+            elif key.startswith("upset_"):
+                kind = "upset"
+            elif key.startswith("alpha_diversity_"):
+                kind = "alpha_diversity"
+            elif key.startswith("beta_diversity_"):
+                kind = "beta_diversity"
+            elif key.startswith("treemap_"):
+                kind = "treemap"
+            elif key.startswith("sunburst_"):
+                kind = "sunburst"
+            elif key.startswith("sankey_"):
+                kind = "sankey"
+            else:
+                kind = "other"
+            label = labels[kind]
+            grouped.setdefault(label, []).append(figure)
+        return grouped
+
+    def _group_basic_figures_by_scope(self, figures: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for figure in figures:
+            scope = self._basic_figure_scope(figure)
+            grouped.setdefault(scope, []).append(figure)
+        ordered: dict[str, list[dict[str, Any]]] = {}
+        for scope in ["Taxa", "Function", "OTF", "Other"]:
+            if scope in grouped:
+                ordered[scope] = grouped[scope]
+        return ordered
+
+    def _basic_figure_scope(self, figure: dict[str, Any]) -> str:
+        key = str(figure.get("key", ""))
+        title = str(figure.get("title", "")).lower()
+        if "_otf_" in key or "taxa-function links" in title:
+            return "OTF"
+        if "_function_" in key or "function abundance" in title:
+            return "Function"
+        if "_taxa_" in key or "taxa abundance" in title:
+            return "Taxa"
+        return "Other"
+
+    def _group_basic_otf_figures_by_function(self, figures: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+        otf_figures = [figure for figure in figures if self._basic_figure_scope(figure) == "OTF"]
+        grouped: dict[str, list[dict[str, Any]]] = {}
+        for figure in otf_figures:
+            function_name = self._figure_function_name(figure)
+            grouped.setdefault(function_name, []).append(figure)
+        ordered: dict[str, list[dict[str, Any]]] = {}
+        for function_name in self.context.function_columns:
+            if function_name in grouped:
+                ordered[function_name] = grouped[function_name]
+        for function_name, items in grouped.items():
+            if function_name not in ordered:
+                ordered[function_name] = items
+        return ordered
+
+    def _figure_function_name(self, figure: dict[str, Any]) -> str:
+        key = str(figure.get("key", ""))
+        title = str(figure.get("title", ""))
+        for function_name in self.context.function_columns:
+            safe_name = _safe_filename(function_name)
+            if safe_name in key or function_name in title:
+                return function_name
+        match = re.search(r"(?:and|with)\s+([A-Za-z0-9_.-]+)", title)
+        if match:
+            return match.group(1)
+        return "Other function"
+
+    def _group_differential_figures(
+        self,
+        figures: list[dict[str, Any]],
+    ) -> dict[str, dict[str, list[dict[str, Any]]]]:
+        grouped: dict[str, dict[str, list[dict[str, Any]]]] = {}
+        for figure in figures:
+            scope = self._differential_scope(figure)
+            plot_type = self._differential_plot_type(figure)
+            if scope == "Taxa" and plot_type in {"Heatmap", "Volcano"}:
+                plot_type = f"{plot_type} - {self._differential_taxa_level(figure)}"
+            grouped.setdefault(scope, {}).setdefault(plot_type, []).append(figure)
+
+        ordered: dict[str, dict[str, list[dict[str, Any]]]] = {}
+        for scope in ["Taxa", "Function", "OTF", "Other"]:
+            if scope in grouped:
+                ordered[scope] = grouped[scope]
+        return ordered
+
+    def _differential_scope(self, figure: dict[str, Any]) -> str:
+        key = str(figure.get("key", ""))
+        title = str(figure.get("title", "")).lower()
+        if "_otf_" in key or "taxa-function links" in title:
+            return "OTF"
+        if "_function_" in key or "function abundance" in title:
+            return "Function"
+        if "_taxa_" in key or "taxa abundance" in title:
+            return "Taxa"
+        return "Other"
+
+    def _differential_plot_type(self, figure: dict[str, Any]) -> str:
+        key = str(figure.get("key", ""))
+        title = str(figure.get("title", "")).lower()
+        if key.startswith("volcano_") or "volcano" in title:
+            return "Volcano"
+        if "heatmap" in key or "heatmap" in title:
+            return "Heatmap"
+        if "sankey" in key or "sankey" in title:
+            return "Sankey"
+        return "Other differential plots"
+
+    def _differential_taxa_level(self, figure: dict[str, Any]) -> str:
+        key = str(figure.get("key", ""))
+        title = str(figure.get("title", "")).lower()
+        for level in self.context.taxa_levels:
+            label = _taxa_level_label(level)
+            if f"_taxa_{level}_" in key or f" {label} " in f" {title} ":
+                return label
+        return "taxa level"
+
+    def _rich_title(self, title: str) -> str:
+        rich = escape(title)
+        tokens: list[tuple[str, str]] = []
+        seen_tokens: set[str] = set()
+
+        def add_token(value: str | None, kind: str) -> None:
+            if not value:
+                return
+            key = str(value)
+            if key in seen_tokens:
+                return
+            seen_tokens.add(key)
+            tokens.append((key, kind))
+
+        for function_name in self.context.function_columns:
+            add_token(function_name, "function")
+        for level in self.context.taxa_levels:
+            label = _taxa_level_label(level)
+            add_token(label, "taxa")
+        control = self.context.config.analysis.control_group
+        group_meta = self.context.config.analysis.group_meta
+        if group_meta and group_meta in self.context.tfa.meta_df.columns:
+            groups = sorted(set(str(item) for item in self.context.tfa.meta_df[group_meta].dropna()))
+            for group in groups:
+                if control and group == control:
+                    continue
+                add_token(group, "group")
+        add_token(control, "control")
+
+        for token, kind in sorted(tokens, key=lambda item: len(item[0]), reverse=True):
+            if not token:
+                continue
+            escaped_token = escape(token)
+            pattern = re.compile(rf"(?<![\w.-]){re.escape(escaped_token)}(?![\w.-])")
+            rich = pattern.sub(f'<span class="title-token title-token-{kind}">{escaped_token}</span>', rich)
+        return rich
+
+
+def _safe_filename(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value.strip())
+    return safe.strip("._") or "preview"
+
+
+def _taxa_level_label(level: str) -> str:
+    labels = {
+        "d": "domain",
+        "p": "phylum",
+        "c": "class",
+        "o": "order",
+        "f": "family",
+        "g": "genus",
+        "s": "species",
+        "m": "genome",
+        "l": "life",
+    }
+    return labels.get(level, level)
+
+
+def _basic_plot_family_notes() -> dict[str, dict[str, str]]:
+    return {
+        "PCA": {
+            "purpose": "Ordination view for checking whether samples separate by the selected metadata group.",
+            "read": "Nearby points have more similar abundance profiles. Clear group separation suggests strong global differences.",
+        },
+        "3D PCA": {
+            "purpose": "Interactive 3D ordination view for datasets where the first two PCs do not capture enough structure.",
+            "read": "Rotate the plot to inspect separation that may be hidden in a 2D projection.",
+        },
+        "t-SNE": {
+            "purpose": "Nonlinear sample embedding for exploratory clustering.",
+            "read": "Use as exploratory evidence only; local neighborhoods are more meaningful than global distances.",
+        },
+        "Correlation Heatmap": {
+            "purpose": "Sample-to-sample similarity check.",
+            "read": "Blocks of high correlation indicate samples with similar taxa/function/OTF profiles.",
+        },
+        "Heatmap": {
+            "purpose": "Top feature abundance patterns across samples.",
+            "read": "Rows are top-N features; columns are samples. Clustering highlights shared abundance patterns.",
+        },
+        "Box": {
+            "purpose": "Intensity distribution by metadata group.",
+            "read": "Large shifts or outlier-heavy groups can indicate normalization or biological differences.",
+        },
+        "Bar": {
+            "purpose": "Composition or abundance contribution of top features.",
+            "read": "Use the interactive legend and zoom controls to focus on major contributors.",
+        },
+        "UpSet": {
+            "purpose": "Feature presence/absence overlap between groups or samples.",
+            "read": "Large intersections show features shared across multiple groups.",
+        },
+        "Alpha Diversity": {
+            "purpose": "Within-sample richness/evenness summary.",
+            "read": "Higher values indicate more diverse abundance profiles within a sample or group.",
+        },
+        "Beta Diversity": {
+            "purpose": "Between-sample distance summary.",
+            "read": "Separated groups indicate distinct community or function profiles.",
+        },
+        "TreeMap": {
+            "purpose": "Hierarchical taxa composition summary.",
+            "read": "Area reflects total abundance; nested boxes follow the taxonomic hierarchy.",
+        },
+        "Sunburst": {
+            "purpose": "Radial hierarchical taxa composition summary.",
+            "read": "Inner rings are broader taxa levels; outer rings are more specific levels.",
+        },
+        "Sankey": {
+            "purpose": "Flow-style view of taxa or taxa-function abundance relationships.",
+            "read": "Wider links represent larger abundance contributions.",
+        },
+    }

--- a/metax/report/paths.py
+++ b/metax/report/paths.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class ReportPaths:
+    output_dir: Path
+
+    def __init__(self, output_dir: str | Path):
+        self.output_dir = Path(output_dir)
+        self.tables_dir = self.output_dir / "tables"
+        self.taxa_tables_dir = self.tables_dir / "taxa"
+        self.function_tables_dir = self.tables_dir / "function"
+        self.otf_tables_dir = self.tables_dir / "otf"
+        self.protein_tables_dir = self.tables_dir / "protein"
+        self.qc_tables_dir = self.tables_dir / "qc"
+        self.stats_dir = self.output_dir / "stats"
+        self.taxa_stats_dir = self.stats_dir / "taxa"
+        self.function_stats_dir = self.stats_dir / "function"
+        self.otf_stats_dir = self.stats_dir / "otf"
+        self.figures_dir = self.output_dir / "figures"
+        self.overview_figures_dir = self.figures_dir / "overview"
+        self.basic_figures_dir = self.figures_dir / "basic"
+        self.composition_figures_dir = self.figures_dir / "composition"
+        self.differential_figures_dir = self.figures_dir / "differential"
+        self.taxa_function_figures_dir = self.figures_dir / "taxa_function"
+        self.assets_dir = self.output_dir / "assets"
+        self.logs_dir = self.output_dir / "logs"
+
+    def create(self) -> None:
+        for path in self.all_dirs():
+            path.mkdir(parents=True, exist_ok=True)
+
+    def all_dirs(self) -> list[Path]:
+        return [
+            self.output_dir,
+            self.tables_dir,
+            self.taxa_tables_dir,
+            self.function_tables_dir,
+            self.otf_tables_dir,
+            self.protein_tables_dir,
+            self.qc_tables_dir,
+            self.stats_dir,
+            self.taxa_stats_dir,
+            self.function_stats_dir,
+            self.otf_stats_dir,
+            self.figures_dir,
+            self.overview_figures_dir,
+            self.basic_figures_dir,
+            self.composition_figures_dir,
+            self.differential_figures_dir,
+            self.taxa_function_figures_dir,
+            self.assets_dir,
+            self.logs_dir,
+        ]

--- a/metax/report/plot_builder.py
+++ b/metax/report/plot_builder.py
@@ -1,0 +1,901 @@
+from __future__ import annotations
+
+import importlib
+import math
+import os
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Iterator
+
+_mpl_config_dir = Path(tempfile.gettempdir()) / "metax_matplotlib"
+_mpl_config_dir.mkdir(parents=True, exist_ok=True)
+os.environ["MPLCONFIGDIR"] = str(_mpl_config_dir)
+
+import matplotlib
+
+matplotlib.use("Agg", force=True)
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .table_builder import safe_filename
+
+if TYPE_CHECKING:
+    from .workflow import ReportContext
+
+
+class PlotBuilder:
+    """Thin orchestration layer around the plotters used by the MetaX GUI."""
+
+    def __init__(self, context: "ReportContext"):
+        self.context = context
+        self.config = context.config
+        self.tfa = context.tfa
+        self._ensure_gui_group()
+        self.basic_plot = self._plotter("metax.taxafunc_ploter.basic_plot", "BasicPlot", self.tfa)
+        self.pca_3d_plot = self._plotter("metax.taxafunc_ploter.pca_plot_js", "PcaPlot_js", self.tfa)
+        self.bar_plot = self._plotter("metax.taxafunc_ploter.bar_plot_js", "BarPlot", self.tfa)
+        self.diversity_plot = self._plotter("metax.taxafunc_ploter.diversity_plot", "DiversityPlot", self.tfa)
+        self.heatmap_plot = self._plotter("metax.taxafunc_ploter.heatmap_plot", "HeatmapPlot", self.tfa)
+        self.network_plot = self._plotter("metax.taxafunc_ploter.network_plot", "NetworkPlot", self.tfa)
+        self.sankey_plot = self._plotter("metax.taxafunc_ploter.sankey_plot", "SankeyPlot", self.tfa)
+        self.sunburst_plot = self._plotter("metax.taxafunc_ploter.sunburst_plot", "SunburstPlot")
+        self.treemap_plot = self._plotter("metax.taxafunc_ploter.treemap_plot", "TreeMapPlot")
+        self.volcano_plot = self._plotter("metax.taxafunc_ploter.volcano_plot", "VolcanoPlot")
+        self.volcano_plot_js = self._plotter("metax.taxafunc_ploter.volcano_plot_js", "VolcanoPlotJS")
+
+    def plot_all(self) -> None:
+        if self.config.plots.run_overview:
+            self.context.logger.info("Generating GUI overview plots")
+            self.plot_overview_gui()
+        self.context.logger.info("Generating GUI basic plots")
+        self.plot_basic_gui()
+        self.context.logger.info("Generating GUI differential plots")
+        self.plot_differential_gui()
+        self.context.logger.info("Skipping standalone taxa-function link plots because OTF plots are shown under Basic Plot")
+
+    def plot_overview_gui(self) -> None:
+        if self.basic_plot is None:
+            return
+        self._plot_optional(
+            "taxa_stats_pie",
+            self.context.paths.overview_figures_dir / "taxa_stats_pie.png",
+            lambda path: self._save_matplotlib(self.basic_plot.plot_taxa_stats_pie(theme="Auto", res_type="pic"), path),
+            title="Taxonomic assignment coverage",
+            description="GUI BasicPlot.plot_taxa_stats_pie overview.",
+            figure_type="overview",
+        )
+        self._plot_optional(
+            "taxa_number_bar",
+            self.context.paths.overview_figures_dir / "taxa_number_bar.png",
+            lambda path: self._save_matplotlib(
+                self.basic_plot.plot_taxa_number(
+                    theme="Auto",
+                    peptide_num=self.config.preprocessing.taxa_peptide_num_threshold,
+                    res_type="pic",
+                ),
+                path,
+            ),
+            title="Detected taxa by level",
+            description="GUI BasicPlot.plot_taxa_number overview.",
+            figure_type="overview",
+        )
+        for func_name in self.context.function_columns:
+            safe_name = safe_filename(func_name)
+            self._plot_optional(
+                f"function_proportion_{safe_name}",
+                self.context.paths.overview_figures_dir / f"function_proportion_{safe_name}.png",
+                lambda path, func_name=func_name: self._save_matplotlib(
+                    self.basic_plot.plot_prop_stats(func_name=func_name, res_type="pic"),
+                    path,
+                ),
+                title=f"Function annotation coverage - {func_name}",
+                description=f"GUI BasicPlot.plot_prop_stats overview for {func_name}.",
+                figure_type="overview",
+            )
+
+    def plot_basic_gui(self) -> None:
+        for table_type in ["taxa", "function", "otf"]:
+            for artifact in self.context.generated_tables.get(table_type, []):
+                matrix = self._matrix_from_table(artifact["df"])
+                if matrix is None or matrix.empty:
+                    self.context.registry.add_warning(
+                        f"No numeric sample matrix available for [{artifact['title']}]. GUI Basic Plot outputs were skipped.",
+                        "PlotBuilder",
+                        details=self._artifact_warning_details(
+                            artifact,
+                            {
+                                "step": "basic plots",
+                                "reason": "no numeric sample columns after table generation",
+                            },
+                        ),
+                    )
+                    continue
+                slug = safe_filename(artifact["key"])
+                title = artifact["title"]
+                top_matrix = self._top_features(matrix, self.config.plots.top_n)
+                log_matrix = self._log2_matrix(matrix)
+                log_top_matrix = self._top_features(log_matrix, self.config.plots.top_n)
+
+                self._plot_pca_family(slug, title, log_matrix)
+                self._plot_distribution_family(slug, title, log_matrix, log_top_matrix, top_matrix)
+                self._plot_diversity_family(slug, title, artifact)
+                self._plot_taxa_composition_family(slug, title, artifact)
+
+    def plot_differential_gui(self) -> None:
+        for stat in self.context.generated_stats:
+            analysis = stat.get("analysis")
+            if analysis in {"anova", "ttest"}:
+                self._plot_test_heatmap(stat)
+            elif analysis == "dunnett_all":
+                self._plot_dunnett_heatmap(stat)
+            elif analysis == "group_vs_control":
+                self._plot_volcano(stat)
+
+    def plot_taxa_function_gui(self) -> None:
+        for artifact in self.context.generated_tables.get("otf", []):
+            matrix = self._matrix_from_table(artifact["df"])
+            if matrix is None or matrix.empty:
+                continue
+            top_matrix = self._top_features(matrix, self.config.plots.network_top_n)
+            slug = safe_filename(artifact["key"])
+            title = artifact["title"]
+
+            if self.config.plots.run_heatmap and self.heatmap_plot is not None:
+                self._plot_optional(
+                    f"tf_link_heatmap_{slug}",
+                    self.context.paths.taxa_function_figures_dir / f"tf_link_heatmap_{slug}.png",
+                    lambda path, top_matrix=top_matrix, title=title: self._save_matplotlib(
+                        self.heatmap_plot.plot_basic_heatmap(
+                            df=top_matrix.copy(),
+                            title=f"Taxa-function link heatmap - {title}",
+                            fig_size=(14, 12),
+                            scale="row",
+                            rename_taxa=True,
+                            font_size=8,
+                            show_all_labels=(top_matrix.shape[1] <= 30, top_matrix.shape[0] <= 50),
+                            linecolor="none",
+                            linewidths=0,
+                        ),
+                        path,
+                    ),
+                    title=f"Taxa-function heatmap - {title}",
+                    description="GUI HeatmapPlot.plot_basic_heatmap on top taxa-function links.",
+                    figure_type="taxa_function",
+                )
+            if self.config.plots.run_bar and self.bar_plot is not None:
+                self._plot_optional(
+                    f"tf_link_bar_{slug}",
+                    self.context.paths.taxa_function_figures_dir / f"tf_link_bar_{slug}.html",
+                    lambda path, top_matrix=top_matrix, title=title: self._save_pyecharts(
+                        self.bar_plot.plot_intensity_bar_js(
+                            df=top_matrix.copy(),
+                            width=1100,
+                            height=700,
+                            title=f"Taxa-function link intensity - {title}",
+                            rename_taxa=True,
+                            show_legend=True,
+                            font_size=9,
+                            rename_sample=False,
+                            plot_mean=True,
+                            plot_percent=False,
+                            sub_meta="None",
+                        ),
+                        path,
+                    ),
+                    title=f"Taxa-function bar - {title}",
+                    description="GUI BarPlot.plot_intensity_bar_js on top taxa-function links.",
+                    figure_type="taxa_function",
+                )
+            if self.config.plots.run_sankey and self.sankey_plot is not None:
+                self._plot_optional(
+                    f"tf_link_sankey_{slug}",
+                    self.context.paths.taxa_function_figures_dir / f"tf_link_sankey_{slug}.html",
+                    lambda path, top_matrix=top_matrix, title=title: self._save_pyecharts(
+                        self.sankey_plot.plot_intensity_sankey(
+                            df=top_matrix.copy(),
+                            width=11,
+                            height=7,
+                            title=f"Taxa-function sankey - {title}",
+                            font_size=10,
+                            show_legend=True,
+                            sub_meta="None",
+                            plot_mean=True,
+                        ),
+                        path,
+                    ),
+                    title=f"Taxa-function Sankey - {title}",
+                    description="GUI SankeyPlot.plot_intensity_sankey on top taxa-function links.",
+                    figure_type="taxa_function",
+                )
+            if self.config.plots.run_network and self.network_plot is not None:
+                self._plot_optional(
+                    f"tf_link_network_{slug}",
+                    self.context.paths.taxa_function_figures_dir / f"tf_link_network_{slug}.html",
+                    lambda path, artifact=artifact, top_matrix=top_matrix: self._plot_network(artifact, top_matrix, path),
+                    title=f"Taxa-function network - {title}",
+                    description="GUI NetworkPlot.plot_tflink_network on top taxa-function links.",
+                    figure_type="taxa_function",
+                )
+
+    def _plot_pca_family(self, slug: str, title: str, matrix: pd.DataFrame) -> None:
+        if self.config.plots.run_pca and self.basic_plot is not None:
+            html_path = self.context.paths.basic_figures_dir / f"pca_{slug}.html"
+            has_js_version = self.pca_3d_plot is not None and min(matrix.shape[0], matrix.shape[1]) >= 3
+            self._plot_optional(
+                f"pca_{slug}",
+                self.context.paths.basic_figures_dir / f"pca_{slug}.png",
+                lambda path, matrix=matrix, title=title, html_path=html_path, has_js_version=has_js_version: self._save_pca_pair(
+                    matrix,
+                    path,
+                    html_path if has_js_version else None,
+                    title,
+                ),
+                title=f"PCA - {title}",
+                description="GUI BasicPlot.plot_pca_sns on log2-transformed abundance; JS version uses GUI PcaPlot_js.plot_pca_pyecharts_3d.",
+                figure_type="basic_pca",
+                alternate_interactive_path=str(html_path) if has_js_version else None,
+                alternate_interactive_title=f"Interactive PCA - {title}" if has_js_version else None,
+            )
+        if self.config.plots.run_pca_3d and self.pca_3d_plot is not None:
+            if min(matrix.shape[0], matrix.shape[1]) < 3:
+                self.context.registry.add_warning(
+                    f"3D PCA skipped for [{title}] because at least 3 samples and features are required.",
+                    "PlotBuilder",
+                    details={
+                        "plot": "3D PCA",
+                        "table": title,
+                        "features": matrix.shape[0],
+                        "samples": matrix.shape[1],
+                        "required": "at least 3 features and 3 samples",
+                    },
+                )
+            else:
+                self._plot_optional(
+                    f"pca_3d_{slug}",
+                    self.context.paths.basic_figures_dir / f"pca_3d_{slug}.html",
+                    lambda path, matrix=matrix, title=title: self._save_pyecharts(
+                        self.pca_3d_plot.plot_pca_pyecharts_3d(
+                            df=matrix.copy(),
+                            title_name=title,
+                            show_label=matrix.shape[1] <= 30,
+                            rename_sample=True,
+                            width=10,
+                            height=7,
+                            font_size=9,
+                            legend_col_num=None,
+                        ),
+                        path,
+                    ),
+                    title=f"3D PCA - {title}",
+                    description="GUI PcaPlot_js.plot_pca_pyecharts_3d.",
+                    figure_type="basic_pca_3d",
+                )
+        if self.config.plots.run_tsne and self.basic_plot is not None:
+            self._plot_optional(
+                f"tsne_{slug}",
+                self.context.paths.basic_figures_dir / f"tsne_{slug}.png",
+                lambda path, matrix=matrix, title=title: self._save_matplotlib(
+                    self.basic_plot.plot_tsne_sns(
+                        df=matrix.copy(),
+                        title_name=title,
+                        show_label=matrix.shape[1] <= 30,
+                        perplexity=max(2, min(30, matrix.shape[1] // 3)),
+                        width=8,
+                        height=6,
+                        font_size=9,
+                        rename_sample=True,
+                        theme="Auto",
+                        legend_col_num=None,
+                    ),
+                    path,
+                ),
+                title=f"t-SNE - {title}",
+                description="GUI BasicPlot.plot_tsne_sns.",
+                figure_type="basic_tsne",
+            )
+
+    def _plot_distribution_family(
+        self,
+        slug: str,
+        title: str,
+        matrix: pd.DataFrame,
+        top_matrix: pd.DataFrame,
+        raw_top_matrix: pd.DataFrame,
+    ) -> None:
+        if self.config.plots.run_correlation and self.basic_plot is not None:
+            self._plot_optional(
+                f"sample_correlation_{slug}",
+                self.context.paths.basic_figures_dir / f"sample_correlation_{slug}.png",
+                lambda path, matrix=matrix, title=title: self._save_matplotlib(
+                    self.basic_plot.plot_corr_sns(
+                        df=matrix.copy(),
+                        title_name=title,
+                        cluster=True,
+                        width=9,
+                        height=8,
+                        font_size=8,
+                        show_all_labels=(matrix.shape[1] <= 30, matrix.shape[1] <= 30),
+                        theme="Auto",
+                        corr_method="pearson",
+                        rename_sample=True,
+                    ),
+                    path,
+                ),
+                title=f"Correlation Heatmap - {title}",
+                description="GUI BasicPlot.plot_corr_sns.",
+                figure_type="basic_correlation",
+            )
+        if self.config.plots.run_heatmap and self.heatmap_plot is not None:
+            self._plot_optional(
+                f"top_feature_heatmap_{slug}",
+                self.context.paths.basic_figures_dir / f"top_feature_heatmap_{slug}.png",
+                lambda path, top_matrix=top_matrix, title=title: self._save_matplotlib(
+                    self.heatmap_plot.plot_basic_heatmap(
+                        df=top_matrix.copy(),
+                        title=f"Top feature heatmap - {title}",
+                        fig_size=(14, 12),
+                        scale="row",
+                        rename_taxa=True,
+                        font_size=8,
+                        show_all_labels=(top_matrix.shape[1] <= 30, top_matrix.shape[0] <= 50),
+                        linecolor="none",
+                        linewidths=0,
+                    ),
+                    path,
+                ),
+                title=f"Heatmap - {title}",
+                description="GUI HeatmapPlot.plot_basic_heatmap on top features.",
+                figure_type="basic_heatmap",
+            )
+        if self.config.plots.run_box and self.basic_plot is not None:
+            self._plot_optional(
+                f"boxplot_{slug}",
+                self.context.paths.basic_figures_dir / f"boxplot_{slug}.png",
+                lambda path, matrix=matrix, title=title: self._save_matplotlib(
+                    self.basic_plot.plot_box_sns(
+                        df=matrix.copy(),
+                        title_name=title,
+                        show_fliers=False,
+                        width=9,
+                        height=6,
+                        font_size=8,
+                        theme="Auto",
+                        rename_sample=False,
+                        plot_samples=False,
+                        legend_col_num=None,
+                        sub_meta="None",
+                    ),
+                    path,
+                ),
+                title=f"Box - {title}",
+                description="GUI BasicPlot.plot_box_sns.",
+                figure_type="basic_box",
+            )
+        if self.config.plots.run_bar and self.bar_plot is not None:
+            html_path = self.context.paths.basic_figures_dir / f"bar_{slug}.html"
+            self._plot_optional(
+                f"bar_{slug}",
+                self.context.paths.basic_figures_dir / f"bar_{slug}.png",
+                lambda path, top_matrix=raw_top_matrix, title=title, html_path=html_path: self._save_bar_pair(top_matrix, path, html_path, title),
+                title=f"Bar - {title}",
+                description="GUI BarPlot.plot_intensity_bar_sns static top-20 per-sample view with GUI BarPlot.plot_intensity_bar_js interactive version.",
+                figure_type="basic_bar",
+                alternate_interactive_path=str(html_path),
+                alternate_interactive_title=f"Interactive Bar - {title}",
+            )
+        if self.config.plots.run_upset and self.basic_plot is not None:
+            self._plot_optional(
+                f"upset_{slug}",
+                self.context.paths.basic_figures_dir / f"upset_{slug}.png",
+                lambda path, top_matrix=top_matrix, title=title: self._plot_upset(top_matrix.copy(), title, path),
+                title=f"UpSet - {title}",
+                description="GUI BasicPlot.plot_upset.",
+                figure_type="basic_upset",
+            )
+
+    def _plot_diversity_family(self, slug: str, title: str, artifact: dict) -> None:
+        if artifact.get("table_type") != "taxa" or self.diversity_plot is None:
+            return
+        gui_df_type = self._gui_df_type(artifact)
+        with self._activate_gui_table(artifact):
+            if self.config.plots.run_diversity and self.config.plots.run_alpha_diversity:
+                self._plot_optional(
+                    f"alpha_diversity_{slug}",
+                    self.context.paths.basic_figures_dir / f"alpha_diversity_{slug}.png",
+                    lambda path, title=title, gui_df_type=gui_df_type: self._save_matplotlib(
+                        self.diversity_plot.plot_alpha_diversity(
+                            metric="shannon",
+                            sample_list=self.tfa.sample_list,
+                            width=8,
+                            height=6,
+                            font_size=8,
+                            plot_all_samples=False,
+                            theme="Auto",
+                            sub_meta="None",
+                            df_type=gui_df_type,
+                            title_name=title,
+                        )[0],
+                        path,
+                    ),
+                    title=f"Alpha Diversity - {title}",
+                    description="GUI DiversityPlot.plot_alpha_diversity.",
+                    figure_type="basic_alpha_diversity",
+                )
+            if self.config.plots.run_diversity and self.config.plots.run_beta_diversity:
+                self._plot_optional(
+                    f"beta_diversity_{slug}",
+                    self.context.paths.basic_figures_dir / f"beta_diversity_{slug}.png",
+                    lambda path, title=title, gui_df_type=gui_df_type: self._save_matplotlib(
+                        self.diversity_plot.plot_beta_diversity(
+                            metric="braycurtis",
+                            sample_list=self.tfa.sample_list,
+                            width=8,
+                            height=6,
+                            font_size=8,
+                            show_label=False,
+                            rename_sample=False,
+                            theme="Auto",
+                            sub_meta="None",
+                            df_type=gui_df_type,
+                            title_name=title,
+                        )[0],
+                        path,
+                    ),
+                    title=f"Beta Diversity - {title}",
+                    description="GUI DiversityPlot.plot_beta_diversity.",
+                    figure_type="basic_beta_diversity",
+                )
+
+    def _plot_taxa_composition_family(self, slug: str, title: str, artifact: dict) -> None:
+        if artifact.get("table_type") != "taxa":
+            return
+        matrix = self._matrix_from_table(artifact["df"])
+        if matrix is None or matrix.empty:
+            return
+        top_matrix = self._top_features(matrix, self.config.plots.top_n)
+        if self.config.plots.run_treemap and self.treemap_plot is not None:
+            self._plot_optional(
+                f"treemap_{slug}",
+                self.context.paths.composition_figures_dir / f"treemap_{slug}.html",
+                lambda path, matrix=top_matrix, title=title: self._save_pyecharts(
+                    self.treemap_plot.create_treemap_chart(
+                        taxa_df=matrix.copy(),
+                        width=10,
+                        height=7,
+                        title=f"TreeMap - {title}",
+                        show_sub_title=False,
+                        font_size=8,
+                    ),
+                    path,
+                ),
+                title=f"TreeMap - {title}",
+                description="GUI TreeMapPlot.create_treemap_chart.",
+                figure_type="basic_treemap",
+            )
+        if self.config.plots.run_sunburst and self.sunburst_plot is not None:
+            self._plot_optional(
+                f"sunburst_{slug}",
+                self.context.paths.composition_figures_dir / f"sunburst_{slug}.html",
+                lambda path, matrix=top_matrix, title=title: self._save_pyecharts(
+                    self.sunburst_plot.create_sunburst_chart(
+                        taxa_df=matrix.copy(),
+                        width=10,
+                        height=7,
+                        title=f"Sunburst - {title}",
+                        show_label="all",
+                        label_font_size=8,
+                    ),
+                    path,
+                ),
+                title=f"Sunburst - {title}",
+                description="GUI SunburstPlot.create_sunburst_chart.",
+                figure_type="basic_sunburst",
+            )
+        if self.config.plots.run_sankey and self.sankey_plot is not None:
+            self._plot_optional(
+                f"sankey_{slug}",
+                self.context.paths.composition_figures_dir / f"sankey_{slug}.html",
+                lambda path, matrix=top_matrix, title=title: self._save_pyecharts(
+                    self.sankey_plot.plot_intensity_sankey(
+                        df=matrix.copy(),
+                        width=11,
+                        height=7,
+                        title=f"Sankey - {title}",
+                        font_size=10,
+                        show_legend=True,
+                        sub_meta="None",
+                        plot_mean=True,
+                    ),
+                    path,
+                ),
+                title=f"Sankey - {title}",
+                description="GUI SankeyPlot.plot_intensity_sankey.",
+                figure_type="basic_sankey",
+            )
+
+    def _plot_test_heatmap(self, stat: dict) -> None:
+        if self.heatmap_plot is None or not self.config.plots.run_heatmap:
+            return
+        slug = safe_filename(stat["key"])
+        self._plot_optional(
+            f"differential_heatmap_{slug}",
+            self.context.paths.differential_figures_dir / f"differential_heatmap_{slug}.png",
+            lambda path, stat=stat: self._save_matplotlib(
+                self.heatmap_plot.plot_basic_heatmap_of_test_res(
+                    df=stat["df"].copy(),
+                    top_number=self.config.plots.heatmap_top_n,
+                    value_type="pvalue",
+                    fig_size=self._differential_heatmap_fig_size(stat["df"]),
+                    pvalue=self.config.statistics.alpha,
+                    scale="row",
+                    rename_taxa=True,
+                    font_size=8,
+                    show_all_labels=(False, True),
+                    sort_by="padj",
+                    p_type="padj",
+                    linecolor="none",
+                ),
+                path,
+            ),
+            title=f"Differential heatmap - {stat['title']}",
+            description="GUI HeatmapPlot.plot_basic_heatmap_of_test_res.",
+            figure_type="differential_heatmap",
+        )
+
+    def _plot_dunnett_heatmap(self, stat: dict) -> None:
+        if self.heatmap_plot is None or not self.config.plots.run_heatmap:
+            return
+        slug = safe_filename(stat["key"])
+        self._plot_optional(
+            f"dunnett_heatmap_{slug}",
+            self.context.paths.differential_figures_dir / f"dunnett_heatmap_{slug}.png",
+            lambda path, stat=stat: self._save_matplotlib(
+                self.heatmap_plot.plot_heatmap_of_dunnett_test_res(
+                    df=stat["df"].copy(),
+                    pvalue=self.config.statistics.alpha,
+                    scale=None,
+                    fig_size=self._differential_heatmap_fig_size(stat["df"]),
+                    rename_taxa=True,
+                    font_size=8,
+                    show_all_labels=(False, True),
+                    p_type="padj",
+                    linecolor="none",
+                ),
+                path,
+            ),
+            title=f"Dunnett heatmap - {stat['title']}",
+            description="GUI HeatmapPlot.plot_heatmap_of_dunnett_test_res.",
+            figure_type="differential_heatmap",
+        )
+
+    def _plot_volcano(self, stat: dict) -> None:
+        if self.volcano_plot is None or not self.config.plots.run_volcano:
+            return
+        volcano_df = stat["df"].copy()
+        if "feature_id" in volcano_df.columns:
+            volcano_df = volcano_df.set_index("feature_id")
+        volcano_df["log2FoldChange"] = pd.to_numeric(volcano_df.get("log2FC"), errors="coerce")
+        volcano_df["pvalue"] = pd.to_numeric(volcano_df.get("p_value"), errors="coerce")
+        volcano_df["padj"] = pd.to_numeric(volcano_df.get("q_value"), errors="coerce").fillna(volcano_df["pvalue"])
+        slug = safe_filename(stat["key"])
+        html_path = self.context.paths.differential_figures_dir / f"volcano_{slug}.html"
+        self._plot_optional(
+            f"volcano_{slug}",
+            self.context.paths.differential_figures_dir / f"volcano_{slug}.png",
+            lambda path, volcano_df=volcano_df, stat=stat, html_path=html_path: self._save_volcano_pair(volcano_df, path, html_path, stat["title"]),
+            title=f"Volcano - {stat['title']}",
+            description="GUI VolcanoPlot.plot_volcano static view with GUI VolcanoPlotJS.plot_volcano_js interactive version.",
+            figure_type="differential_volcano",
+            alternate_interactive_path=str(html_path),
+            alternate_interactive_title=f"Interactive Volcano - {stat['title']}",
+        )
+
+    def _save_volcano_pair(self, volcano_df: pd.DataFrame, png_path: Path, html_path: Path, title: str) -> None:
+        self._save_matplotlib(
+            self.volcano_plot.plot_volcano(
+                df_fc=volcano_df.copy(),
+                pvalue=self.config.statistics.alpha,
+                p_type="padj",
+                log2fc_min=self.config.statistics.log2fc_cutoff,
+                title_name=title,
+                font_size=10,
+                width=10,
+                height=7,
+                dot_size=6,
+                theme="Auto",
+            ),
+            png_path,
+        )
+        if self.volcano_plot_js is not None:
+            self._save_pyecharts(
+                self.volcano_plot_js.plot_volcano_js(
+                    df_fc=volcano_df.copy(),
+                    pvalue=self.config.statistics.alpha,
+                    p_type="padj",
+                    log2fc_min=self.config.statistics.log2fc_cutoff,
+                    title_name=title,
+                    font_size=10,
+                    width=10,
+                    height=7,
+                    dot_size=6,
+                ),
+                html_path,
+            )
+
+    def _save_pca_pair(self, matrix: pd.DataFrame, png_path: Path, html_path: Path | None, title: str) -> None:
+        self._save_matplotlib(
+            self.basic_plot.plot_pca_sns(
+                df=matrix.copy(),
+                title_name=title,
+                show_label=matrix.shape[1] <= 30,
+                width=8,
+                height=6,
+                font_size=9,
+                rename_sample=True,
+                theme="Auto",
+                legend_col_num=None,
+            ),
+            png_path,
+        )
+        if html_path is not None and self.pca_3d_plot is not None:
+            self._save_pyecharts(
+                self.pca_3d_plot.plot_pca_pyecharts_3d(
+                    df=matrix.copy(),
+                    title_name=title,
+                    show_label=matrix.shape[1] <= 30,
+                    rename_sample=True,
+                    width=10,
+                    height=7,
+                    font_size=9,
+                    legend_col_num=None,
+                ),
+                html_path,
+            )
+
+    def _save_bar_pair(self, matrix: pd.DataFrame, png_path: Path, html_path: Path, title: str) -> None:
+        static_width = max(12, min(24, matrix.shape[1] * 0.08))
+        self._save_matplotlib(
+            self.bar_plot.plot_intensity_bar_sns(
+                df=matrix.copy(),
+                width=static_width,
+                height=8,
+                title=f"Top 20 intensity bar - {title}",
+                rename_taxa=True,
+                show_legend=True,
+                font_size=8,
+                rename_sample=True,
+                plot_mean=False,
+                plot_percent=False,
+                sub_meta="None",
+                plt_theme="Auto",
+            ),
+            png_path,
+        )
+        self._save_pyecharts(
+            self.bar_plot.plot_intensity_bar_js(
+                df=matrix.copy(),
+                width=1200,
+                height=800,
+                title=f"Top 20 intensity bar - {title}",
+                rename_taxa=True,
+                show_legend=True,
+                font_size=9,
+                rename_sample=True,
+                plot_mean=False,
+                plot_percent=False,
+                sub_meta="None",
+                show_all_labels=(False, False),
+            ),
+            html_path,
+        )
+
+    def _plot_upset(self, matrix: pd.DataFrame, title: str, path: Path) -> None:
+        self.basic_plot.plot_upset(
+            df=matrix,
+            title_name=title,
+            width=12,
+            height=6,
+            font_size=9,
+            plot_sample=False,
+            sub_meta="None",
+            show_label=True,
+            rename_sample=False,
+        )
+        self._save_matplotlib(plt.gcf(), path)
+
+    def _plot_network(self, artifact: dict, top_matrix: pd.DataFrame, path: Path) -> None:
+        with self._activate_gui_table(artifact, df_override=top_matrix):
+            chart, _, _ = self.network_plot.plot_tflink_network(
+                sample_list=list(top_matrix.columns),
+                width=11,
+                height=7,
+                focus_list=[],
+                plot_list_only=False,
+            )
+            self._save_pyecharts(chart, path)
+
+    def _plotter(self, module_name: str, class_name: str, *args: Any, **kwargs: Any) -> Any | None:
+        try:
+            module = importlib.import_module(module_name)
+            plotter_cls = getattr(module, class_name)
+            return plotter_cls(*args, **kwargs)
+        except Exception as exc:
+            self.context.registry.add_warning(
+                f"GUI plotter [{class_name}] is unavailable and related plots will be skipped: {exc}",
+                "PlotBuilder",
+                details={
+                    "module": module_name,
+                    "class": class_name,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+    def _plot_optional(
+        self,
+        key: str,
+        path: Path,
+        action: Callable[[Path], None],
+        title: str,
+        description: str,
+        figure_type: str,
+        **metadata: Any,
+    ) -> None:
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            action(path)
+            self.context.registry.add_figure(key, path, title=title, description=description, figure_type=figure_type, **metadata)
+            self.context.logger.info("Generated figure: %s", path)
+        except Exception as exc:
+            self.context.logger.exception("Optional GUI plot failed: %s", key)
+            self.context.registry.add_warning(
+                f"Optional GUI plot [{title}] failed: {exc}",
+                "PlotBuilder",
+                details=self._plot_warning_details(key, path, title, figure_type, metadata, exc),
+            )
+        finally:
+            plt.close("all")
+
+    def _plot_warning_details(
+        self,
+        key: str,
+        path: Path,
+        title: str,
+        figure_type: str,
+        metadata: dict[str, Any],
+        exc: Exception,
+    ) -> dict[str, Any]:
+        details: dict[str, Any] = {
+            "plot_key": key,
+            "plot_title": title,
+            "figure_type": figure_type,
+            "output_path": str(path),
+            "error": str(exc),
+            "top_n": self.config.plots.top_n,
+            "heatmap_top_n": self.config.plots.heatmap_top_n,
+        }
+        details.update({name: value for name, value in metadata.items() if value is not None})
+        for level in self.context.taxa_levels:
+            if f"_taxa_{level}" in key or f"_{level}_" in key:
+                details.setdefault("taxa_level", level)
+                break
+        for function_name in self.context.function_columns:
+            safe_name = safe_filename(function_name)
+            if safe_name in key or function_name in title:
+                details.setdefault("function_column", function_name)
+                break
+        return details
+
+    def _artifact_warning_details(self, artifact: dict[str, Any], extra: dict[str, Any] | None = None) -> dict[str, Any]:
+        details: dict[str, Any] = {
+            "table_key": artifact.get("key"),
+            "table_title": artifact.get("title"),
+            "table_type": artifact.get("table_type"),
+            "taxa_level": artifact.get("taxa_level"),
+            "function_column": artifact.get("function_column"),
+            "rows": artifact.get("df").shape[0] if hasattr(artifact.get("df"), "shape") else None,
+        }
+        if extra:
+            details.update(extra)
+        return {key: value for key, value in details.items() if value is not None and value != ""}
+
+    def _save_matplotlib(self, plot_obj: Any, path: Path) -> None:
+        if isinstance(plot_obj, tuple):
+            plot_obj = plot_obj[0]
+        if hasattr(plot_obj, "savefig"):
+            fig = plot_obj
+        elif hasattr(plot_obj, "fig") and hasattr(plot_obj.fig, "savefig"):
+            fig = plot_obj.fig
+        elif hasattr(plot_obj, "figure") and hasattr(plot_obj.figure, "savefig"):
+            fig = plot_obj.figure
+        elif hasattr(plot_obj, "get_figure"):
+            fig = plot_obj.get_figure()
+        else:
+            fig = plt.gcf()
+        fig.savefig(path, dpi=180, bbox_inches="tight")
+
+    def _save_pyecharts(self, chart: Any, path: Path) -> None:
+        if isinstance(chart, tuple):
+            chart = chart[0]
+        chart.render(str(path))
+
+    @contextmanager
+    def _activate_gui_table(self, artifact: dict, df_override: pd.DataFrame | None = None) -> Iterator[str]:
+        df_type = artifact.get("df_type")
+        old_state = {
+            "taxa_df": getattr(self.tfa, "taxa_df", None),
+            "func_df": getattr(self.tfa, "func_df", None),
+            "taxa_func_df": getattr(self.tfa, "taxa_func_df", None),
+            "func_name": getattr(self.tfa, "func_name", None),
+            "taxa_level": getattr(self.tfa, "taxa_level", None),
+        }
+        table_df = df_override.copy() if df_override is not None else artifact["df"].copy()
+        try:
+            if df_type == "taxa":
+                self.tfa.taxa_df = table_df
+                if artifact.get("taxa_level"):
+                    self.tfa.taxa_level = artifact["taxa_level"]
+            elif df_type == "func":
+                self.tfa.func_df = table_df
+                if artifact.get("function_column"):
+                    self.tfa.func_name = artifact["function_column"]
+            elif df_type == "taxa-func":
+                self.tfa.taxa_func_df = table_df
+                if artifact.get("function_column"):
+                    self.tfa.func_name = artifact["function_column"]
+                if artifact.get("taxa_level"):
+                    self.tfa.taxa_level = artifact["taxa_level"]
+            yield self._gui_df_type(artifact)
+        finally:
+            for attr, value in old_state.items():
+                setattr(self.tfa, attr, value)
+
+    def _ensure_gui_group(self) -> None:
+        group_meta = self.config.analysis.group_meta
+        if group_meta and group_meta in self.tfa.meta_df.columns:
+            self.tfa.set_group(group_meta)
+            return
+        if getattr(self.tfa, "group_list", None) is not None:
+            return
+        fallback_group = "AutoReportGroup"
+        if fallback_group not in self.tfa.meta_df.columns:
+            self.tfa.meta_df[fallback_group] = "All"
+        self.tfa.set_group(fallback_group)
+
+    def _matrix_from_table(self, df: pd.DataFrame) -> pd.DataFrame | None:
+        sample_cols = [sample for sample in self.tfa.sample_list or [] if sample in df.columns]
+        if not sample_cols:
+            return None
+        matrix = df[sample_cols].apply(pd.to_numeric, errors="coerce").fillna(0)
+        matrix = matrix.loc[(matrix != 0).any(axis=1)]
+        return matrix
+
+    def _top_features(self, matrix: pd.DataFrame, top_n: int) -> pd.DataFrame:
+        if matrix.empty:
+            return matrix
+        means = matrix.mean(axis=1).sort_values(ascending=False)
+        return matrix.loc[means.head(top_n).index]
+
+    def _log2_matrix(self, matrix: pd.DataFrame) -> pd.DataFrame:
+        values = matrix.apply(pd.to_numeric, errors="coerce").fillna(0)
+        pseudo_count = self.config.statistics.pseudo_count
+        return values.apply(lambda column: column.map(lambda value: math.log2(max(float(value), 0.0) + pseudo_count)))
+
+    def _differential_heatmap_fig_size(self, df: pd.DataFrame) -> tuple[float, float]:
+        matrix = self._matrix_from_table(df)
+        n_cols = matrix.shape[1] if matrix is not None and not matrix.empty else 2
+        n_rows = min(self.config.plots.heatmap_top_n, len(df)) if len(df) else 10
+        width = max(8.0, min(18.0, 6.5 + n_cols * 0.55))
+        if n_cols <= 3:
+            width = 8.5
+        elif n_cols <= 8:
+            width = 10.5
+        height = max(7.0, min(24.0, 4.5 + n_rows * 0.28))
+        return (width, height)
+
+    def _gui_df_type(self, artifact: dict) -> str:
+        df_type = artifact.get("df_type")
+        if df_type == "taxa-func":
+            return "taxa_func"
+        return str(df_type)

--- a/metax/report/registry.py
+++ b/metax/report/registry.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+class ResultRegistry:
+    def __init__(self) -> None:
+        self.tables: list[dict[str, Any]] = []
+        self.stats: list[dict[str, Any]] = []
+        self.figures: list[dict[str, Any]] = []
+        self.html: list[dict[str, Any]] = []
+        self.warnings: list[dict[str, Any]] = []
+        self.errors: list[dict[str, Any]] = []
+        self.runtime: dict[str, Any] = {
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+    def add_table(
+        self,
+        key: str,
+        path: str | Path,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.tables.append(self._artifact(key, path, title, description))
+
+    def add_stat(
+        self,
+        key: str,
+        path: str | Path,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.stats.append(self._artifact(key, path, title, description))
+
+    def add_figure(
+        self,
+        key: str,
+        path: str | Path,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        figure_type: Optional[str] = None,
+        **metadata: Any,
+    ) -> None:
+        item = self._artifact(key, path, title, description)
+        if figure_type:
+            item["figure_type"] = figure_type
+        item.update(metadata)
+        self.figures.append(item)
+
+    def add_html(
+        self,
+        key: str,
+        path: str | Path,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> None:
+        self.html.append(self._artifact(key, path, title, description))
+
+    def add_warning(
+        self,
+        message: str,
+        source: Optional[str] = None,
+        details: Optional[dict[str, Any]] = None,
+    ) -> None:
+        item: dict[str, Any] = {"message": message, "source": source}
+        if details:
+            item["details"] = details
+        self.warnings.append(item)
+
+    def add_error(self, message: str, source: Optional[str] = None) -> None:
+        self.errors.append({"message": message, "source": source})
+
+    def set_runtime(self, key: str, value: Any) -> None:
+        self.runtime[key] = value
+
+    def finish(self) -> None:
+        self.runtime["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tables": self.tables,
+            "stats": self.stats,
+            "figures": self.figures,
+            "html": self.html,
+            "warnings": self.warnings,
+            "errors": self.errors,
+            "runtime": self.runtime,
+        }
+
+    def save_json(self, path: str | Path) -> None:
+        output_path = Path(path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as handle:
+            json.dump(self.to_dict(), handle, indent=2)
+
+    @staticmethod
+    def _artifact(
+        key: str,
+        path: str | Path,
+        title: Optional[str],
+        description: Optional[str],
+    ) -> dict[str, Any]:
+        return {
+            "key": key,
+            "path": str(path),
+            "title": title or key,
+            "description": description,
+        }

--- a/metax/report/stats_builder.py
+++ b/metax/report/stats_builder.py
@@ -1,0 +1,474 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Iterator
+
+import numpy as np
+import pandas as pd
+
+from .table_builder import safe_filename
+
+if TYPE_CHECKING:
+    from .workflow import ReportContext
+
+
+class StatsBuilder:
+    """Run the same statistical backend used by the MetaX GUI."""
+
+    def __init__(self, context: "ReportContext"):
+        self.context = context
+        self.config = context.config
+        self.tfa = context.tfa
+
+    def run_all(self) -> None:
+        group_meta = self.config.analysis.group_meta
+        control_group = self.config.analysis.control_group
+        if self.config.statistics.run_deseq2:
+            self.context.registry.add_warning(
+                "DESeq2-like analysis was requested, but the auto report does not enable it by default. "
+                "The GUI-compatible ANOVA/Dunnett workflow was used instead.",
+                "StatsBuilder",
+                details={
+                    "requested_method": "DESeq2",
+                    "fallback_backend": "MetaX GUI CrossTest",
+                    "run_deseq2": self.config.statistics.run_deseq2,
+                },
+            )
+        if str(self.config.statistics.diff_method).lower() not in {"dunnett", "gui_dunnett"}:
+            self.context.registry.add_warning(
+                f"diff_method [{self.config.statistics.diff_method}] is not a GUI group-vs-control method; "
+                "using MetaX GUI Dunnett statistics for report consistency.",
+                "StatsBuilder",
+                details={
+                    "configured_diff_method": self.config.statistics.diff_method,
+                    "used_method": "MetaX GUI Dunnett",
+                    "reason": "report reuses GUI statistical backend",
+                },
+            )
+        if not group_meta:
+            self.context.logger.info("Skipping statistics because no group_meta is configured.")
+            return
+        if group_meta not in self.tfa.meta_df.columns:
+            raise ValueError(f"group_meta [{group_meta}] is not in metadata columns.")
+
+        self.tfa.set_group(group_meta)
+        groups = self._valid_group_names()
+        if len(groups) < 2:
+            self.context.registry.add_warning(
+                f"Too few groups for statistical testing in [{group_meta}].",
+                "StatsBuilder",
+                details={
+                    "group_meta": group_meta,
+                    "groups": groups,
+                    "required_groups": "at least 2",
+                },
+            )
+            return
+
+        for table_type in ["taxa", "function", "otf"]:
+            for artifact in self.context.generated_tables.get(table_type, []):
+                with self._activate_gui_table(artifact, transform_for_stats=True) as df_type:
+                    if self.config.statistics.run_anova and len(groups) > 2:
+                        self._run_gui_anova(table_type, artifact, df_type, groups)
+                    elif self.config.statistics.run_ttest and len(groups) == 2:
+                        self._run_gui_ttest(table_type, artifact, df_type, groups)
+                    if control_group and self.config.statistics.run_group_vs_control:
+                        self._run_gui_dunnett(table_type, artifact, df_type, groups, str(control_group))
+
+    def _run_gui_anova(self, table_type: str, artifact: dict, df_type: str, groups: list[str]) -> None:
+        if len(groups) <= 2:
+            self.context.registry.add_warning(
+                f"ANOVA skipped for [{artifact['title']}] because MetaX GUI ANOVA requires more than two groups.",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="anova",
+                    groups=groups,
+                    reason="requires more than two groups",
+                ),
+            )
+            return
+
+        try:
+            result = self.tfa.CrossTest.get_stats_anova(group_list=list(groups), df_type=df_type)
+        except Exception as exc:
+            self.context.logger.exception("GUI ANOVA failed for %s", artifact["key"])
+            self.context.registry.add_warning(
+                f"GUI ANOVA failed for [{artifact['title']}]: {exc}",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="anova",
+                    groups=groups,
+                    error=exc,
+                ),
+            )
+            return
+
+        path = self._stats_dir(table_type) / f"{safe_filename(artifact['key'])}_anova.tsv"
+        self._save_stat(
+            key=f"{artifact['key']}_anova",
+            path=path,
+            df=result,
+            title=f"ANOVA - {artifact['title']}",
+            description="MetaX GUI ANOVA result generated with CrossTest.get_stats_anova.",
+            analysis="anova",
+            table_type=table_type,
+            source_key=artifact["key"],
+            index=True,
+            backend="metax_gui",
+        )
+
+    def _run_gui_ttest(self, table_type: str, artifact: dict, df_type: str, groups: list[str]) -> None:
+        if len(groups) != 2:
+            return
+
+        try:
+            result = self.tfa.CrossTest.get_stats_ttest(group_list=list(groups), df_type=df_type)
+        except Exception as exc:
+            self.context.logger.exception("GUI t-test failed for %s", artifact["key"])
+            self.context.registry.add_warning(
+                f"GUI t-test failed for [{artifact['title']}]: {exc}",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="ttest",
+                    groups=groups,
+                    error=exc,
+                ),
+            )
+            return
+
+        path = self._stats_dir(table_type) / f"{safe_filename(artifact['key'])}_ttest.tsv"
+        self._save_stat(
+            key=f"{artifact['key']}_ttest",
+            path=path,
+            df=result,
+            title=f"T-test - {artifact['title']}",
+            description="MetaX GUI t-test result generated with CrossTest.get_stats_ttest on log2(x + 1) abundance.",
+            analysis="ttest",
+            table_type=table_type,
+            source_key=artifact["key"],
+            index=True,
+            backend="metax_gui",
+        )
+
+    def _run_gui_dunnett(
+        self,
+        table_type: str,
+        artifact: dict,
+        df_type: str,
+        groups: list[str],
+        control_group: str,
+    ) -> None:
+        if control_group not in groups:
+            raise ValueError(f"control_group [{control_group}] is not present in configured groups.")
+        comparison_groups = [group for group in groups if group != control_group]
+        if not comparison_groups:
+            self.context.registry.add_warning(
+                f"Dunnett comparison skipped for [{artifact['title']}] because no non-control groups were available.",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="dunnett",
+                    groups=groups,
+                    control=control_group,
+                    reason="no non-control groups",
+                ),
+            )
+            return
+
+        try:
+            result = self.tfa.CrossTest.get_stats_dunnett_test(
+                control_group=control_group,
+                group_list=list(groups),
+                df_type=df_type,
+            )
+        except Exception as exc:
+            self.context.logger.exception("GUI Dunnett test failed for %s", artifact["key"])
+            self.context.registry.add_warning(
+                f"GUI Dunnett test failed for [{artifact['title']}]: {exc}",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="dunnett",
+                    groups=groups,
+                    control=control_group,
+                    error=exc,
+                ),
+            )
+            return
+
+        raw_path = self._stats_dir(table_type) / f"{safe_filename(artifact['key'])}_dunnett.tsv"
+        self._save_stat(
+            key=f"{artifact['key']}_dunnett",
+            path=raw_path,
+            df=result,
+            title=f"Dunnett test - {artifact['title']}",
+            description="MetaX GUI group-vs-control result generated with CrossTest.get_stats_dunnett_test.",
+            analysis="dunnett_all",
+            table_type=table_type,
+            source_key=artifact["key"],
+            index=True,
+            backend="metax_gui",
+            control=control_group,
+        )
+
+        matrix = self._matrix_from_table(self._log2_for_stats(artifact["df"]))
+        if matrix is None or matrix.empty:
+            self.context.registry.add_warning(
+                f"Pairwise Dunnett summaries skipped for [{artifact['title']}] because no numeric matrix was available.",
+                "StatsBuilder",
+                details=self._warning_details(
+                    artifact,
+                    analysis="pairwise_dunnett_summary",
+                    groups=groups,
+                    control=control_group,
+                    reason="no numeric sample matrix",
+                ),
+            )
+            return
+
+        for group in comparison_groups:
+            pair_df = self._dunnett_pair_summary(result, matrix, group, control_group)
+            safe_group = safe_filename(group)
+            safe_control = safe_filename(control_group)
+            path = self._stats_dir(table_type) / f"{safe_filename(artifact['key'])}_{safe_group}_vs_{safe_control}.tsv"
+            self._save_stat(
+                key=f"{artifact['key']}_{safe_group}_vs_{safe_control}",
+                path=path,
+                df=pair_df,
+                title=f"{group} vs {control_group} - {artifact['title']}",
+                description=(
+                    "Report-friendly pairwise summary derived from the MetaX GUI Dunnett result on log2(x + 1) abundance. "
+                    "p_value/q_value/statistic come from CrossTest; log2FC is the difference between mean log2 abundances."
+                ),
+                analysis="group_vs_control",
+                table_type=table_type,
+                source_key=artifact["key"],
+                index=False,
+                backend="metax_gui",
+                group=group,
+                control=control_group,
+                raw_stat_key=f"{artifact['key']}_dunnett",
+            )
+
+    def _dunnett_pair_summary(
+        self,
+        dunnett_df: pd.DataFrame,
+        matrix: pd.DataFrame,
+        group: str,
+        control: str,
+    ) -> pd.DataFrame:
+        if not isinstance(dunnett_df.columns, pd.MultiIndex) or group not in dunnett_df.columns.get_level_values(0):
+            raise ValueError(f"Dunnett result does not contain group [{group}].")
+
+        group_samples = [sample for sample in self.tfa.get_sample_list_in_a_group(group) if sample in matrix.columns]
+        control_samples = [sample for sample in self.tfa.get_sample_list_in_a_group(control) if sample in matrix.columns]
+        p_values = pd.to_numeric(dunnett_df[(group, "pvalue")], errors="coerce")
+        q_values = pd.to_numeric(dunnett_df[(group, "padj")], errors="coerce")
+        statistic = pd.to_numeric(dunnett_df[(group, "statistic")], errors="coerce")
+
+        rows = []
+        for feature_id in matrix.index:
+            group_values = matrix.loc[feature_id, group_samples].dropna()
+            control_values = matrix.loc[feature_id, control_samples].dropna()
+            mean_group = float(group_values.mean()) if len(group_values) else np.nan
+            mean_control = float(control_values.mean()) if len(control_values) else np.nan
+            median_group = float(group_values.median()) if len(group_values) else np.nan
+            median_control = float(control_values.median()) if len(control_values) else np.nan
+            log2fc = float(mean_group - mean_control)
+            p_value = float(p_values.loc[feature_id]) if feature_id in p_values.index and pd.notna(p_values.loc[feature_id]) else np.nan
+            q_value = float(q_values.loc[feature_id]) if feature_id in q_values.index and pd.notna(q_values.loc[feature_id]) else np.nan
+            stat_value = float(statistic.loc[feature_id]) if feature_id in statistic.index and pd.notna(statistic.loc[feature_id]) else np.nan
+            significant = bool(
+                pd.notna(q_value)
+                and q_value <= self.config.statistics.alpha
+                and abs(log2fc) >= self.config.statistics.log2fc_cutoff
+            )
+            direction = "not_significant"
+            if significant and log2fc > 0:
+                direction = "up"
+            elif significant and log2fc < 0:
+                direction = "down"
+            rows.append(
+                {
+                    "feature_id": feature_id,
+                    "group": group,
+                    "control": control,
+                    "n_group": int(len(group_values)),
+                    "n_control": int(len(control_values)),
+                    "mean_group": mean_group,
+                    "mean_control": mean_control,
+                    "median_group": median_group,
+                    "median_control": median_control,
+                    "log2FC": log2fc,
+                    "p_value": p_value,
+                    "q_value": q_value,
+                    "t_statistic": stat_value,
+                    "test_method": f"MetaX GUI Dunnett test on log2(x + {self.config.statistics.pseudo_count}) abundance",
+                    "significant": significant,
+                    "direction": direction,
+                }
+            )
+        return pd.DataFrame(rows)
+
+    @contextmanager
+    def _activate_gui_table(self, artifact: dict, transform_for_stats: bool = False) -> Iterator[str]:
+        df_type = artifact.get("df_type")
+        if df_type not in {"taxa", "func", "taxa-func"}:
+            raise ValueError(f"Unsupported table type for GUI statistics: {artifact.get('key')}")
+
+        old_state = {
+            "taxa_df": getattr(self.tfa, "taxa_df", None),
+            "func_df": getattr(self.tfa, "func_df", None),
+            "taxa_func_df": getattr(self.tfa, "taxa_func_df", None),
+            "func_name": getattr(self.tfa, "func_name", None),
+            "taxa_level": getattr(self.tfa, "taxa_level", None),
+        }
+        table_df = self._log2_for_stats(artifact["df"]) if transform_for_stats else artifact["df"].copy()
+        try:
+            if df_type == "taxa":
+                self.tfa.taxa_df = table_df
+                if artifact.get("taxa_level"):
+                    self.tfa.taxa_level = artifact["taxa_level"]
+            elif df_type == "func":
+                self.tfa.func_df = table_df
+                if artifact.get("function_column"):
+                    self.tfa.func_name = artifact["function_column"]
+            elif df_type == "taxa-func":
+                self.tfa.taxa_func_df = table_df
+                if artifact.get("function_column"):
+                    self.tfa.func_name = artifact["function_column"]
+                if artifact.get("taxa_level"):
+                    self.tfa.taxa_level = artifact["taxa_level"]
+            yield df_type
+        finally:
+            for attr, value in old_state.items():
+                setattr(self.tfa, attr, value)
+
+    def _save_stat(
+        self,
+        key: str,
+        path: Path,
+        df: pd.DataFrame,
+        title: str,
+        description: str,
+        analysis: str,
+        table_type: str,
+        source_key: str,
+        index: bool,
+        backend: str,
+        group: str | None = None,
+        control: str | None = None,
+        raw_stat_key: str | None = None,
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(path, sep="\t", index=index)
+        self.context.registry.add_stat(key, path, title=title, description=description)
+        self.context.generated_stats.append(
+            {
+                "key": key,
+                "path": path,
+                "title": title,
+                "description": description,
+                "df": df.copy(),
+                "analysis": analysis,
+                "table_type": table_type,
+                "source_key": source_key,
+                "group": group,
+                "control": control,
+                "backend": backend,
+                "raw_stat_key": raw_stat_key,
+            }
+        )
+        self.context.logger.info("Generated statistics: %s", path)
+
+    def _valid_group_names(self) -> list[str]:
+        group_names = sorted(set(str(group) for group in self.tfa.get_meta_list(self.tfa.meta_name)))
+        valid_groups = []
+        for group in group_names:
+            try:
+                if self.tfa.get_sample_list_in_a_group(group):
+                    valid_groups.append(group)
+            except Exception:
+                continue
+        return valid_groups
+
+    def _matrix_from_table(self, df: pd.DataFrame) -> pd.DataFrame | None:
+        sample_cols = [sample for sample in self.tfa.sample_list or [] if sample in df.columns]
+        if not sample_cols:
+            return None
+        matrix = df[sample_cols].apply(pd.to_numeric, errors="coerce").fillna(0)
+        matrix = matrix.loc[(matrix != 0).any(axis=1)]
+        return matrix
+
+    def _log2_for_stats(self, df: pd.DataFrame) -> pd.DataFrame:
+        sample_cols = [sample for sample in self.tfa.sample_list or [] if sample in df.columns]
+        transformed = df.copy()
+        if not sample_cols:
+            return transformed
+        values = transformed[sample_cols].apply(pd.to_numeric, errors="coerce").fillna(0)
+        transformed[sample_cols] = np.log2(values + self.config.statistics.pseudo_count)
+        return transformed
+
+    def _feature_labels(self, df: pd.DataFrame) -> list[str]:
+        if isinstance(df.index, pd.MultiIndex):
+            return [" | ".join(str(part) for part in index) for index in df.index]
+        return [str(index) for index in df.index]
+
+    def _stats_dir(self, table_type: str) -> Path:
+        if table_type == "taxa":
+            return self.context.paths.taxa_stats_dir
+        if table_type == "function":
+            return self.context.paths.function_stats_dir
+        if table_type == "otf":
+            return self.context.paths.otf_stats_dir
+        return self.context.paths.stats_dir
+
+    def _warning_details(
+        self,
+        artifact: dict,
+        analysis: str,
+        groups: list[str] | None = None,
+        control: str | None = None,
+        reason: str | None = None,
+        error: Exception | None = None,
+    ) -> dict[str, object]:
+        details: dict[str, object] = {
+            "analysis": analysis,
+            "table_key": artifact.get("key"),
+            "table_title": artifact.get("title"),
+            "table_type": artifact.get("table_type"),
+            "taxa_level": artifact.get("taxa_level"),
+            "function_column": artifact.get("function_column"),
+            "groups": groups,
+            "control_group": control or self.config.analysis.control_group,
+            "group_meta": self.config.analysis.group_meta,
+            "alpha": self.config.statistics.alpha,
+            "log2fc_cutoff": self.config.statistics.log2fc_cutoff,
+            "pseudo_count": self.config.statistics.pseudo_count,
+            "transform": f"log2(x + {self.config.statistics.pseudo_count})",
+            "reason": reason,
+            "error": str(error) if error else None,
+        }
+        return {key: value for key, value in details.items() if value is not None and value != ""}
+
+
+def _bh_fdr(p_values: np.ndarray) -> np.ndarray:
+    p_values = np.asarray(p_values, dtype=float)
+    q_values = np.full_like(p_values, np.nan, dtype=float)
+    valid = np.isfinite(p_values)
+    if not valid.any():
+        return q_values
+    valid_indices = np.where(valid)[0]
+    valid_p = p_values[valid]
+    order = np.argsort(valid_p)
+    ranked = valid_p[order]
+    n = len(ranked)
+    adjusted = ranked * n / np.arange(1, n + 1)
+    adjusted = np.minimum.accumulate(adjusted[::-1])[::-1]
+    adjusted = np.clip(adjusted, 0, 1)
+    q_values[valid_indices[order]] = adjusted
+    return q_values

--- a/metax/report/table_builder.py
+++ b/metax/report/table_builder.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from .workflow import ReportContext
+
+
+VALID_TAXA_LEVELS = {"d", "p", "c", "o", "f", "g", "s", "m", "l"}
+DEFAULT_ALL_TAXA_LEVELS = ["d", "p", "c", "o", "f", "g", "s"]
+DEFAULT_EXCLUDED_FUNCTION_COLUMNS = {
+    "protein_id",
+    "EC_DE",
+    "EC_AN",
+    "EC_CC",
+    "EC_CA",
+    "KEGG_Pathway",
+    "KEGG_ko",
+    "None_func",
+}
+REPORT_DEFAULT_FUNCTION_PRIORITY = ("KEGG_ko_name", "KEGG_ko")
+REPORT_DEFAULT_ADDITIONAL_FUNCTIONS = ("Gene",)
+
+
+class TableBuilder:
+    def __init__(self, context: "ReportContext"):
+        self.context = context
+        self.config = context.config
+        self.tfa = context.tfa
+
+    def build_all(self) -> None:
+        self.context.logger.info("Generating report tables")
+        self.context.function_columns = self.resolve_function_columns()
+        self.context.taxa_levels = self.resolve_taxa_levels()
+
+        if self.config.tables.generate_taxa_tables:
+            self.build_taxa_tables()
+        if self.config.tables.generate_function_tables:
+            self.build_function_tables()
+        if self.config.tables.generate_otf_tables:
+            self.build_otf_tables()
+
+        self.build_qc_tables()
+
+    def resolve_taxa_levels(self) -> list[str]:
+        taxa_levels = self.config.tables.taxa_levels
+        if taxa_levels == ["all"]:
+            return DEFAULT_ALL_TAXA_LEVELS
+        invalid = [level for level in taxa_levels if level not in VALID_TAXA_LEVELS]
+        if invalid:
+            raise ValueError(f"Invalid taxa level(s): {invalid}. Valid levels: {sorted(VALID_TAXA_LEVELS)}")
+        return taxa_levels
+
+    def resolve_function_columns(self) -> list[str]:
+        available = [
+            item
+            for item in (self.tfa.func_list or [])
+            if item in self.tfa.original_df.columns and f"{item}_prop" in self.tfa.original_df.columns
+        ]
+        if self.config.tables.function_columns == "auto":
+            selected = self._resolve_auto_report_function_columns(available)
+        else:
+            requested = list(self.config.tables.function_columns)
+            missing = [item for item in requested if item not in available]
+            if missing:
+                raise ValueError(
+                    f"Requested function column(s) not found or missing *_prop column: {missing}. "
+                    f"Available function columns: {available}"
+                )
+            selected = requested
+
+        main_function = self.config.analysis.main_function
+        if main_function:
+            if main_function not in available:
+                raise ValueError(f"main_function [{main_function}] is not available. Available: {available}")
+            selected = [main_function] + [item for item in selected if item != main_function]
+
+        if not selected:
+            self.context.registry.add_warning(
+                "No usable function annotation columns were detected.",
+                "TableBuilder",
+                details={
+                    "requested_function_columns": self.config.tables.function_columns,
+                    "available_function_columns": available,
+                },
+            )
+        return selected
+
+    def _resolve_auto_report_function_columns(self, available: list[str]) -> list[str]:
+        selected: list[str] = []
+        if REPORT_DEFAULT_FUNCTION_PRIORITY[0] in available:
+            selected.append(REPORT_DEFAULT_FUNCTION_PRIORITY[0])
+        elif REPORT_DEFAULT_FUNCTION_PRIORITY[1] in available:
+            selected.append(REPORT_DEFAULT_FUNCTION_PRIORITY[1])
+            self.context.registry.add_warning(
+                "Function column [KEGG_ko_name] was not available; using [KEGG_ko] for the KEGG report default.",
+                "TableBuilder",
+                details={
+                    "requested_default": "KEGG_ko_name",
+                    "fallback": "KEGG_ko",
+                    "available_function_columns": available,
+                },
+            )
+        else:
+            self.context.registry.add_warning(
+                "Neither [KEGG_ko_name] nor [KEGG_ko] was available for the KEGG report default.",
+                "TableBuilder",
+                details={
+                    "requested_defaults": list(REPORT_DEFAULT_FUNCTION_PRIORITY),
+                    "available_function_columns": available,
+                },
+            )
+
+        for func_name in REPORT_DEFAULT_ADDITIONAL_FUNCTIONS:
+            if func_name in available and func_name not in selected:
+                selected.append(func_name)
+
+        if selected:
+            return selected
+
+        fallback = [item for item in available if item not in DEFAULT_EXCLUDED_FUNCTION_COLUMNS]
+        if fallback:
+            self.context.registry.add_warning(
+                f"Using fallback function annotation columns because report defaults were unavailable: {fallback}",
+                "TableBuilder",
+                details={
+                    "fallback_function_columns": fallback,
+                    "available_function_columns": available,
+                },
+            )
+            return fallback
+        return available
+
+    def build_taxa_tables(self) -> None:
+        kwargs = self._preprocess_kwargs()
+        for level in self.context.taxa_levels:
+            path = self.context.paths.taxa_tables_dir / f"taxa_table_{level}.tsv"
+            try:
+                df = self.tfa._create_taxa_table_only_from_otf(level=level, **kwargs)
+                df = df.drop(columns=["peptide_num"], errors="ignore")
+                self._save_table(df, path)
+                self._register_table(
+                    "taxa",
+                    f"taxa_{level}",
+                    path,
+                    df,
+                    f"Taxa abundance - {taxa_level_label(level)} level",
+                    f"Abundance summarized by {taxa_level_label(level)}.",
+                    df_type="taxa",
+                    taxa_level=level,
+                )
+            except Exception as exc:
+                self.context.logger.exception("Failed to generate taxa table for level %s", level)
+                self.context.registry.add_warning(
+                    f"Taxa table for level [{level}] failed: {exc}",
+                    "TableBuilder",
+                    details=self._warning_details(
+                        table_type="taxa",
+                        taxa_level=level,
+                        function_column=None,
+                        error=exc,
+                    ),
+                )
+
+    def build_function_tables(self) -> None:
+        kwargs = self._preprocess_kwargs()
+        for func_name in self.context.function_columns:
+            safe_name = safe_filename(func_name)
+            path = self.context.paths.function_tables_dir / f"function_table_{safe_name}.tsv"
+            try:
+                df = self.tfa._create_func_table_only_from_otf(
+                    func_name=func_name,
+                    func_threshold=1.0,
+                    keep_unknow_func=self.config.tables.keep_unknown_func,
+                    split_func=self.config.tables.split_func,
+                    split_func_params={
+                        "split_by": self.config.tables.split_by,
+                        "share_intensity": self.config.tables.share_intensity,
+                    },
+                    **kwargs,
+                )
+                df = df.drop(columns=["peptide_num"], errors="ignore")
+                self._save_table(df, path)
+                self._register_table(
+                    "function",
+                    f"function_{safe_name}",
+                    path,
+                    df,
+                    f"Function abundance - {func_name}",
+                    f"Abundance summarized by the {func_name} annotation.",
+                    df_type="func",
+                    function_column=func_name,
+                )
+            except Exception as exc:
+                self.context.logger.exception("Failed to generate function table for %s", func_name)
+                self.context.registry.add_warning(
+                    f"Function table for [{func_name}] failed: {exc}",
+                    "TableBuilder",
+                    details=self._warning_details(
+                        table_type="function",
+                        taxa_level=None,
+                        function_column=func_name,
+                        error=exc,
+                    ),
+                )
+
+    def build_otf_tables(self) -> None:
+        kwargs = self._preprocess_kwargs()
+        protein_saved = False
+        for level in self.context.taxa_levels:
+            for func_name in self.context.function_columns:
+                safe_name = safe_filename(func_name)
+                path = self.context.paths.otf_tables_dir / f"otf_table_{level}_{safe_name}.tsv"
+                try:
+                    self.tfa.set_func(func_name)
+                    self.tfa.set_multi_tables(
+                        level=level,
+                        keep_unknow_func=self.config.tables.keep_unknown_func,
+                        sum_protein=self.config.tables.generate_protein_table and not protein_saved,
+                        sum_protein_params={
+                            "method": "anti-razor",
+                            "by_sample": False,
+                            "rank_method": "unique_counts",
+                            "greedy_method": "heap",
+                            "peptide_num_threshold": self.config.preprocessing.otf_peptide_num_threshold,
+                        },
+                        split_func=self.config.tables.split_func,
+                        split_func_params={
+                            "split_by": self.config.tables.split_by,
+                            "share_intensity": self.config.tables.share_intensity,
+                        },
+                        taxa_and_func_only_from_otf=False,
+                        func_threshold=1.0,
+                        **kwargs,
+                    )
+                    if self.config.tables.generate_protein_table and not protein_saved:
+                        self._save_protein_table()
+                        protein_saved = True
+
+                    df = self.tfa.get_df("taxa_func")
+                    self._save_table(df, path)
+                    self._register_table(
+                        "otf",
+                        f"otf_{level}_{safe_name}",
+                        path,
+                        df,
+                        f"Taxa-function links - {taxa_level_label(level)} and {func_name}",
+                        f"OTF abundance linking {taxa_level_label(level)} taxa to {func_name} functions.",
+                        df_type="taxa-func",
+                        taxa_level=level,
+                        function_column=func_name,
+                    )
+                except Exception as exc:
+                    self.context.logger.exception("Failed to generate OTF table for %s / %s", level, func_name)
+                    self.context.registry.add_warning(
+                        f"OTF table for level [{level}] and function [{func_name}] failed: {exc}",
+                        "TableBuilder",
+                        details=self._warning_details(
+                            table_type="otf",
+                            taxa_level=level,
+                            function_column=func_name,
+                            error=exc,
+                        ),
+                    )
+
+    def build_qc_tables(self) -> None:
+        self.context.logger.info("Generating QC tables")
+        sample_qc = self._build_sample_qc()
+        sample_qc_path = self.context.paths.qc_tables_dir / "sample_qc.tsv"
+        sample_qc.to_csv(sample_qc_path, sep="\t", index=False)
+        self._register_table(
+            "qc",
+            "sample_qc",
+            sample_qc_path,
+            sample_qc.set_index("sample") if "sample" in sample_qc.columns else sample_qc,
+            "Sample quality summary",
+            "Per-sample intensity totals, feature counts, and missingness.",
+        )
+
+        for table_type in ["taxa", "function", "otf"]:
+            df = self._first_table_df(table_type)
+            prevalence = self._build_feature_prevalence(df)
+            path = self.context.paths.qc_tables_dir / f"feature_prevalence_{table_type}.tsv"
+            prevalence.to_csv(path, sep="\t", index=False)
+            self._register_table(
+                "qc",
+                f"feature_prevalence_{table_type}",
+                path,
+                prevalence.set_index("feature_id") if "feature_id" in prevalence.columns else prevalence,
+                f"Feature prevalence - {table_type}",
+                f"How often features are detected across samples in the first {table_type} result.",
+            )
+
+    def _build_sample_qc(self) -> pd.DataFrame:
+        sample_list = list(self.tfa.sample_list or [])
+        original_matrix = self.tfa.original_df[sample_list].apply(pd.to_numeric, errors="coerce")
+        group_map = self._sample_group_map()
+
+        data: dict[str, Any] = {
+            "sample": sample_list,
+            "group": [group_map.get(sample, "All") for sample in sample_list],
+            "total_intensity": [original_matrix[sample].sum(skipna=True) for sample in sample_list],
+        }
+
+        for table_type in ["taxa", "function", "otf"]:
+            df = self._first_table_df(table_type)
+            counts, missing = self._sample_feature_metrics(df, sample_list)
+            data[f"nonzero_feature_count_{table_type}"] = counts
+            data[f"missing_fraction_{table_type}"] = missing
+
+        return pd.DataFrame(data)
+
+    def _build_feature_prevalence(self, df: pd.DataFrame | None) -> pd.DataFrame:
+        columns = [
+            "feature_id",
+            "mean_intensity",
+            "median_intensity",
+            "nonzero_sample_count",
+            "prevalence",
+        ]
+        sample_list = list(self.tfa.sample_list or [])
+        if df is None or df.empty:
+            return pd.DataFrame(columns=columns)
+
+        matrix = df[[sample for sample in sample_list if sample in df.columns]].apply(pd.to_numeric, errors="coerce")
+        nonzero = matrix.fillna(0) != 0
+        result = pd.DataFrame(
+            {
+                "feature_id": self._feature_ids(df),
+                "mean_intensity": matrix.mean(axis=1, skipna=True).values,
+                "median_intensity": matrix.median(axis=1, skipna=True).values,
+                "nonzero_sample_count": nonzero.sum(axis=1).values,
+                "prevalence": nonzero.mean(axis=1).values,
+            }
+        )
+
+        group_meta = self.config.analysis.group_meta
+        if group_meta and group_meta in self.tfa.meta_df.columns:
+            for group, samples in self.tfa.meta_df.groupby(group_meta)["Sample"]:
+                valid_samples = [sample for sample in samples.tolist() if sample in matrix.columns]
+                if valid_samples:
+                    result[f"prevalence_{safe_filename(str(group))}"] = nonzero[valid_samples].mean(axis=1).values
+        return result
+
+    def _sample_feature_metrics(self, df: pd.DataFrame | None, sample_list: list[str]) -> tuple[list[int], list[float]]:
+        if df is None or df.empty:
+            return [0 for _ in sample_list], [1.0 for _ in sample_list]
+        matrix = df[[sample for sample in sample_list if sample in df.columns]].apply(pd.to_numeric, errors="coerce")
+        counts: list[int] = []
+        missing: list[float] = []
+        for sample in sample_list:
+            if sample not in matrix.columns:
+                counts.append(0)
+                missing.append(1.0)
+                continue
+            values = matrix[sample]
+            counts.append(int((values.fillna(0) != 0).sum()))
+            missing.append(float(((values.isna()) | (values == 0)).mean()))
+        return counts, missing
+
+    def _save_protein_table(self) -> None:
+        protein_df = self.tfa.get_df("protein")
+        path = self.context.paths.protein_tables_dir / "protein_table.tsv"
+        self._save_table(protein_df, path)
+        self._register_table(
+            "protein",
+            "protein",
+            path,
+            protein_df,
+            "Protein abundance",
+            "Protein-level abundance summarized during OTF table generation.",
+            df_type="protein",
+        )
+
+    def _save_table(self, df: pd.DataFrame, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(path, sep="\t", index=True)
+
+    def _register_table(
+        self,
+        table_type: str,
+        key: str,
+        path: Path,
+        df: pd.DataFrame,
+        title: str,
+        description: str,
+        **metadata: Any,
+    ) -> None:
+        artifact = {
+            "key": key,
+            "path": path,
+            "title": title,
+            "description": description,
+            "df": df.copy(),
+            "table_type": table_type,
+            **metadata,
+        }
+        self.context.generated_tables.setdefault(table_type, []).append(artifact)
+        self.context.registry.add_table(key, path, title=title, description=description)
+        self.context.logger.info("Generated table: %s", path)
+
+    def _first_table_df(self, table_type: str) -> pd.DataFrame | None:
+        items = self.context.generated_tables.get(table_type, [])
+        if not items:
+            return None
+        return items[0]["df"]
+
+    def _sample_group_map(self) -> dict[str, str]:
+        group_meta = self.config.analysis.group_meta
+        if not group_meta or group_meta not in self.tfa.meta_df.columns:
+            return {sample: "All" for sample in self.tfa.sample_list or []}
+        return dict(zip(self.tfa.meta_df["Sample"], self.tfa.meta_df[group_meta].astype(str)))
+
+    def _feature_ids(self, df: pd.DataFrame) -> list[str]:
+        if isinstance(df.index, pd.MultiIndex):
+            return [" | ".join(str(part) for part in index) for index in df.index]
+        return [str(index) for index in df.index]
+
+    def _preprocess_kwargs(self) -> dict[str, Any]:
+        preprocessing = self.config.preprocessing
+        return {
+            "outlier_params": {
+                "detect_method": preprocessing.outlier_detect_method,
+                "handle_method": preprocessing.outlier_handle_method,
+                "detection_by_group": preprocessing.detection_by_group,
+                "handle_by_group": preprocessing.handle_by_group,
+            },
+            "data_preprocess_params": {
+                "normalize_method": preprocessing.normalize_method,
+                "transform_method": preprocessing.transform_method,
+                "batch_meta": preprocessing.batch_meta,
+                "processing_order": ["transform", "normalize", "batch"],
+            },
+            "peptide_num_threshold": {
+                "taxa": preprocessing.taxa_peptide_num_threshold,
+                "func": preprocessing.func_peptide_num_threshold,
+                "taxa_func": preprocessing.otf_peptide_num_threshold,
+            },
+            "quant_method": preprocessing.quant_method,
+        }
+
+    def _warning_details(
+        self,
+        table_type: str,
+        taxa_level: str | None,
+        function_column: str | None,
+        error: Exception,
+    ) -> dict[str, Any]:
+        preprocessing = self.config.preprocessing
+        details: dict[str, Any] = {
+            "table_type": table_type,
+            "taxa_level": taxa_level,
+            "function_column": function_column,
+            "error": str(error),
+            "quant_method": preprocessing.quant_method,
+            "outlier_detect_method": preprocessing.outlier_detect_method,
+            "outlier_handle_method": preprocessing.outlier_handle_method,
+            "normalize_method": preprocessing.normalize_method,
+            "transform_method": preprocessing.transform_method,
+            "taxa_peptide_num_threshold": preprocessing.taxa_peptide_num_threshold,
+            "func_peptide_num_threshold": preprocessing.func_peptide_num_threshold,
+            "otf_peptide_num_threshold": preprocessing.otf_peptide_num_threshold,
+            "split_func": self.config.tables.split_func,
+            "split_by": self.config.tables.split_by,
+            "keep_unknown_func": self.config.tables.keep_unknown_func,
+        }
+        return {key: value for key, value in details.items() if value is not None and value != ""}
+
+
+def safe_filename(value: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", value.strip())
+    return safe.strip("._") or "unnamed"
+
+
+def taxa_level_label(level: str) -> str:
+    labels = {
+        "d": "domain",
+        "p": "phylum",
+        "c": "class",
+        "o": "order",
+        "f": "family",
+        "g": "genus",
+        "s": "species",
+        "m": "genome",
+        "l": "life",
+    }
+    return labels.get(level, level)

--- a/metax/report/templates/figure_tile.html.j2
+++ b/metax/report/templates/figure_tile.html.j2
@@ -1,0 +1,46 @@
+<div class="figure-tile" data-search-item="{{ (figure.title ~ ' ' ~ figure.description ~ ' ' ~ figure.relative_path)|lower }}">
+  <div>
+    <div class="artifact-title">{{ figure.rich_title|default(figure.title)|safe }}</div>
+    {% if figure.description %}
+      <details class="figure-meta-details">
+        <summary>Details</summary>
+        <div class="artifact-meta">{{ figure.description }}</div>
+      </details>
+    {% endif %}
+  </div>
+  {% if figure.relative_path.lower().endswith(".png") %}
+    <img src="{{ figure.relative_path }}" alt="{{ figure.title }}" loading="lazy">
+    <div class="artifact-actions">
+      <button class="action-button primary" data-open-figure="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">Preview</button>
+      {% if figure.alternate_interactive_relative_path %}
+        <button class="action-button" data-open-interactive="{{ figure.alternate_interactive_relative_path }}" data-figure-title="{{ figure.alternate_interactive_title|default(figure.title) }}">JS version</button>
+      {% endif %}
+      {% if figure.table_preview_relative_path %}
+        <button class="action-button" data-open-table="{{ figure.table_preview_relative_path }}" data-figure-title="{{ figure.table_title|default('Result table') }}">Table</button>
+      {% endif %}
+      <a class="action-link" href="{{ figure.relative_path }}">Export</a>
+    </div>
+  {% elif figure.relative_path.lower().endswith(".html") %}
+    <button class="interactive-thumb" type="button" data-open-interactive="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">
+      <span class="interactive-mark">HTML</span>
+      <span class="interactive-copy">
+        <strong>Interactive plot</strong>
+        <span>Preview in a large viewer</span>
+      </span>
+    </button>
+    <div class="artifact-actions">
+      <button class="action-button primary" data-open-interactive="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">Preview</button>
+      {% if figure.table_preview_relative_path %}
+        <button class="action-button" data-open-table="{{ figure.table_preview_relative_path }}" data-figure-title="{{ figure.table_title|default('Result table') }}">Table</button>
+      {% endif %}
+      <a class="action-link" href="{{ figure.relative_path }}">Export</a>
+    </div>
+  {% else %}
+    <div class="artifact-actions">
+      {% if figure.table_preview_relative_path %}
+        <button class="action-button" data-open-table="{{ figure.table_preview_relative_path }}" data-figure-title="{{ figure.table_title|default('Result table') }}">Table</button>
+      {% endif %}
+      <a class="action-link" href="{{ figure.relative_path }}">Open figure</a>
+    </div>
+  {% endif %}
+</div>

--- a/metax/report/templates/report.html.j2
+++ b/metax/report/templates/report.html.j2
@@ -1,0 +1,565 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ title }}</title>
+  {% if favicon_path %}
+  <link rel="icon" href="{{ favicon_path }}" type="image/png">
+  {% endif %}
+  <style>
+    :root {
+      --page: #f5f3ef;
+      --surface: #fffdfa;
+      --surface-raised: #ffffff;
+      --surface-soft: #f7faf8;
+      --ink: #202833;
+      --subtle: #66727f;
+      --line: #ded8cf;
+      --line-strong: #cfc7ba;
+      --primary: #136f63;
+      --primary-soft: #e2f1ed;
+      --blue: #2f5f8f;
+      --blue-soft: #e8eef7;
+      --coral: #b15b44;
+      --coral-soft: #f8e9e4;
+      --gold: #8a6500;
+      --gold-soft: #fff4d7;
+      --danger: #9f1d1d;
+      --danger-soft: #fff0f0;
+      --sidebar-accent: #136f63;
+      --sidebar-accent-soft: #edf6f3;
+      --sidebar-hover: #f0ede7;
+      --shadow: 0 16px 40px rgba(32, 40, 51, .08);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      background: var(--page);
+      color: var(--ink);
+      font: 14px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    body.modal-open { overflow: hidden; }
+    a { color: var(--primary); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    h1, h2, h3 { margin: 0; line-height: 1.2; }
+    h1 { font-size: 26px; }
+    h2 { font-size: 20px; }
+    h3 { font-size: 15px; }
+    p { margin: 0; }
+    button, input { font: inherit; }
+    .app-shell { min-height: 100vh; display: grid; grid-template-columns: 286px minmax(0, 1fr); }
+    .sidebar {
+      position: sticky;
+      top: 0;
+      height: 100vh;
+      overflow: auto;
+      background: #fbfaf7;
+      border-right: 1px solid var(--line);
+      padding: 22px 18px;
+    }
+    .brand { border-bottom: 1px solid var(--line); padding: 0 4px 20px; margin-bottom: 18px; }
+    .brand-mark {
+      width: min(232px, 100%); aspect-ratio: 1 / 1; border-radius: 18px; background: transparent;
+      display: grid; place-items: center; font-weight: 800; margin-bottom: 10px;
+      border: 0; overflow: hidden;
+    }
+    .brand-mark img { display: block; width: 100%; height: 100%; object-fit: contain; padding: 12px; }
+    .brand-title { font-size: 18px; font-weight: 750; }
+    .brand-subtitle { color: var(--subtle); font-size: 12px; margin-top: 4px; }
+    .nav-label {
+      color: var(--subtle); font-size: 11px; text-transform: uppercase; letter-spacing: .08em;
+      margin: 18px 6px 8px;
+    }
+    .nav-button {
+      width: 100%; border: 0; border-radius: 10px; background: transparent; color: var(--ink);
+      padding: 10px; cursor: pointer; text-align: left; display: grid;
+      grid-template-columns: 30px minmax(0, 1fr) auto; gap: 8px; align-items: center;
+    }
+    .nav-button:hover { background: var(--sidebar-hover); }
+    .nav-button.active { background: var(--sidebar-accent); color: #fff; box-shadow: 0 8px 18px rgba(19, 111, 99, .18); }
+    .nav-icon {
+      width: 26px; height: 26px; border-radius: 8px; display: grid; place-items: center;
+      background: rgba(32, 40, 51, .08); font-size: 12px; font-weight: 750;
+    }
+    .nav-button.active .nav-icon { background: rgba(255, 255, 255, .18); }
+    .nav-title { font-weight: 650; overflow-wrap: anywhere; }
+    .nav-note { color: var(--subtle); font-size: 12px; margin-top: 1px; display: block; }
+    .nav-button.active .nav-note { color: rgba(255, 255, 255, .78); }
+    .count-pill {
+      min-width: 28px; padding: 2px 8px; border-radius: 999px; background: #e9e3d8;
+      color: #3c4651; font-size: 12px; text-align: center; font-weight: 650;
+    }
+    .nav-button.active .count-pill { background: rgba(255, 255, 255, .2); color: #fff; }
+    .side-summary {
+      margin-top: 20px; padding: 12px; border: 1px solid var(--line); border-radius: 12px; background: #fffdfa;
+    }
+    .side-summary-title { font-weight: 700; margin-bottom: 8px; }
+    .side-summary-row {
+      display: flex; justify-content: space-between; gap: 10px; color: var(--subtle);
+      font-size: 12px; padding: 4px 0;
+    }
+    .side-summary-row strong { color: var(--ink); }
+    .content { min-width: 0; padding: 28px; }
+    .report-hero {
+      background: var(--surface-raised); border: 1px solid var(--line); border-radius: 18px;
+      box-shadow: var(--shadow); padding: 26px; margin-bottom: 20px; display: grid;
+      grid-template-columns: minmax(0, 1fr) auto; gap: 22px; align-items: start;
+    }
+    .eyebrow {
+      color: var(--primary); font-weight: 750; font-size: 12px; text-transform: uppercase;
+      letter-spacing: .08em; margin-bottom: 7px;
+    }
+    .hero-copy { color: var(--subtle); max-width: 760px; margin-top: 8px; }
+    .quick-links, .artifact-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+    .action-link, .action-button {
+      display: inline-flex; align-items: center; justify-content: center; min-height: 34px;
+      border: 1px solid var(--line-strong); border-radius: 9px; background: #fffdfa;
+      color: var(--ink); padding: 7px 11px; cursor: pointer; white-space: nowrap;
+    }
+    .action-link:hover, .action-button:hover { border-color: var(--primary); text-decoration: none; }
+    .action-button.primary { border-color: var(--primary); background: var(--primary); color: #fff; }
+    .view-section { display: none; }
+    .view-section.active { display: block; }
+    .panel {
+      background: var(--surface-raised); border: 1px solid var(--line); border-radius: 16px;
+      padding: 22px; margin-bottom: 18px; box-shadow: 0 8px 24px rgba(32, 40, 51, .05);
+    }
+    .panel-header {
+      display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 18px; align-items: start; margin-bottom: 18px;
+    }
+    .panel-kicker {
+      color: var(--subtle); font-size: 12px; text-transform: uppercase; letter-spacing: .08em;
+      margin-bottom: 5px; font-weight: 700;
+    }
+    .panel-help { color: var(--subtle); margin-top: 7px; max-width: 760px; }
+    .muted { color: var(--subtle); }
+    .metric-grid, .task-grid, .file-grid, .figure-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 12px;
+    }
+    .figure-grid { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 16px; }
+    .metric, .task-card, .artifact, .figure-tile, .function-panel {
+      border: 1px solid var(--line); border-radius: 14px; background: #fffdfa; padding: 15px;
+    }
+    .artifact-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 14px;
+      align-items: start;
+    }
+    .metric.primary { background: var(--primary-soft); border-color: #c6dfd8; }
+    .metric.blue { background: var(--blue-soft); border-color: #ced9ea; }
+    .metric.coral { background: var(--coral-soft); border-color: #edcfc5; }
+    .metric.gold { background: var(--gold-soft); border-color: #e7d8a6; }
+    .metric .label { color: var(--subtle); font-size: 12px; text-transform: uppercase; font-weight: 700; }
+    .metric .value { font-size: 23px; font-weight: 760; margin-top: 5px; overflow-wrap: anywhere; }
+    .metric .hint { color: var(--subtle); font-size: 12px; margin-top: 5px; }
+    .task-card, .figure-tile { display: grid; gap: 10px; }
+    .task-top { display: flex; align-items: center; gap: 9px; }
+    .task-badge {
+      width: 28px; height: 28px; border-radius: 8px; background: var(--primary-soft);
+      color: var(--primary); display: grid; place-items: center; font-weight: 800;
+    }
+    .toolbar {
+      display: flex; flex-wrap: wrap; justify-content: space-between; gap: 10px; align-items: center; margin-bottom: 14px;
+    }
+    .search-input {
+      min-height: 38px; width: min(380px, 100%); border: 1px solid var(--line-strong);
+      border-radius: 10px; background: #fffdfa; color: var(--ink); padding: 8px 10px;
+    }
+    .tab-strip { display: flex; flex-wrap: wrap; gap: 8px; margin: 12px 0 16px; border-bottom: 1px solid var(--line); padding-bottom: 10px; }
+    .tab-button {
+      border: 1px solid var(--line-strong); border-radius: 999px; background: #fffdfa;
+      color: var(--ink); padding: 7px 12px; cursor: pointer;
+    }
+    .tab-button.active { border-color: var(--primary); background: var(--primary-soft); color: #003f36; font-weight: 750; }
+    .tab-panel { display: none; }
+    .tab-panel.active { display: block; }
+    .sub-tabs { margin-top: 8px; }
+    .subgroup-heading {
+      display: flex; justify-content: space-between; align-items: start; gap: 12px; margin: 8px 0 12px;
+    }
+    .subgroup-summary { color: var(--subtle); margin: 6px 0 10px; }
+    .function-panel-stack { display: grid; gap: 16px; }
+    .section-context, .family-note {
+      border: 1px solid var(--line); border-radius: 14px; background: var(--surface-soft);
+      padding: 13px; margin-bottom: 16px; color: var(--subtle);
+    }
+    .section-context strong, .family-note strong { color: var(--ink); }
+    .family-context { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; margin-bottom: 16px; }
+    .family-note-label {
+      color: var(--subtle); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; font-weight: 750; margin-bottom: 4px;
+    }
+    .artifact-title { font-weight: 750; overflow-wrap: anywhere; }
+    .figure-meta-details { margin-top: 6px; }
+    .figure-meta-details summary {
+      cursor: pointer;
+      color: var(--primary);
+      font-size: 12px;
+      font-weight: 750;
+    }
+    .title-token {
+      display: inline-block; border-radius: 999px; padding: 1px 7px; margin: 0 1px;
+      font-weight: 800; line-height: 1.45;
+    }
+    .title-token-function { background: var(--blue-soft); color: var(--blue); }
+    .title-token-taxa { background: var(--primary-soft); color: var(--primary); }
+    .title-token-group { background: var(--coral-soft); color: var(--coral); }
+    .title-token-control { background: var(--gold-soft); color: var(--gold); }
+    .artifact-meta, .file-path { color: var(--subtle); font-size: 13px; margin-top: 4px; overflow-wrap: anywhere; }
+    .file-path { color: #7a7166; font-size: 12px; margin-top: 6px; }
+    .preview-frame {
+      display: none; width: 100%; height: 430px; margin-top: 12px;
+      border: 1px solid var(--line); border-radius: 12px; background: #fff;
+    }
+    .preview-frame.active { display: block; }
+    .figure-tile img {
+      display: block; width: 100%; max-height: 500px; object-fit: contain;
+      border: 1px solid var(--line); border-radius: 12px; background: #fff;
+    }
+    .interactive-thumb {
+      width: 100%; min-height: 170px; border: 1px dashed var(--line-strong); border-radius: 12px;
+      background: linear-gradient(135deg, #fffdfa, var(--surface-soft)); color: var(--ink);
+      display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 12px;
+      padding: 18px; cursor: pointer; text-align: left;
+    }
+    .interactive-thumb:hover { border-color: var(--primary); background: var(--primary-soft); }
+    .interactive-mark {
+      width: 54px; height: 54px; border-radius: 14px; display: grid; place-items: center;
+      background: var(--primary); color: #fff; font-weight: 850; font-size: 12px; letter-spacing: .04em;
+    }
+    .interactive-copy { display: grid; gap: 3px; min-width: 0; }
+    .interactive-copy span { color: var(--subtle); font-size: 13px; }
+    .empty-state {
+      border: 1px dashed var(--line-strong); border-radius: 14px; background: #fffdfa;
+      padding: 18px; color: var(--subtle);
+    }
+    .message { border-left: 5px solid var(--gold); background: var(--gold-soft); padding: 11px 13px; margin: 9px 0; border-radius: 8px; }
+    .message.error { border-left-color: var(--danger); background: var(--danger-soft); }
+    details.config-block summary { cursor: pointer; color: var(--primary); font-weight: 750; margin-bottom: 10px; }
+    pre {
+      overflow: auto; background: #1f2933; color: #f7fafc; border-radius: 12px;
+      padding: 14px; font-size: 12px; max-height: 420px;
+    }
+    .modal {
+      position: fixed; inset: 0; display: none; align-items: center; justify-content: center;
+      padding: 24px; background: rgba(32, 40, 51, .62); z-index: 10; overscroll-behavior: contain;
+    }
+    .modal.active { display: flex; }
+    .modal-panel {
+      width: min(1100px, 96vw); max-height: 92vh; overflow: auto; border-radius: 16px;
+      background: #fffdfa; padding: 16px; box-shadow: 0 22px 60px rgba(0, 0, 0, .2);
+      overscroll-behavior: contain;
+    }
+    .modal-panel.image-preview, .modal-panel.interactive, .modal-panel.table-preview {
+      width: min(1500px, 98vw); height: min(920px, 94vh); display: grid; grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+    }
+    .modal-header { display: flex; justify-content: space-between; gap: 12px; align-items: center; margin-bottom: 12px; }
+    .modal-title-area { display: flex; align-items: center; gap: 12px; min-width: 0; }
+    .modal-title-area h3 { overflow-wrap: anywhere; }
+    .modal-tools { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+    .zoom-label { min-width: 46px; text-align: center; color: var(--subtle); font-size: 12px; }
+    .image-stage {
+      display: none; overflow: auto; min-height: 0; border: 1px solid var(--line);
+      border-radius: 12px; background: #fff; overscroll-behavior: contain;
+    }
+    .modal-panel.image-preview .image-stage { display: block; }
+    .modal img { width: 100%; max-width: none; height: auto; display: block; }
+    .modal iframe {
+      width: 100%; height: 100%; min-height: 680px; border: 1px solid var(--line);
+      border-radius: 12px; background: #fff; display: none; pointer-events: auto; overscroll-behavior: contain;
+    }
+    .modal-panel.interactive iframe, .modal-panel.table-preview iframe { display: block; }
+    @media (max-width: 880px) {
+      .app-shell { grid-template-columns: 1fr; }
+      .sidebar { position: static; height: auto; border-right: 0; border-bottom: 1px solid var(--line); }
+      .content { padding: 16px; }
+      .report-hero, .panel-header { grid-template-columns: 1fr; }
+      .quick-links, .artifact-actions { justify-content: flex-start; }
+      .search-input { width: 100%; }
+    }
+  </style>
+</head>
+<body>
+  <div class="app-shell">
+    <aside class="sidebar">
+      <div class="brand">
+        <div class="brand-mark">
+          {% if favicon_path %}
+            <img src="{{ favicon_path }}" alt="MetaX">
+          {% else %}
+            M
+          {% endif %}
+        </div>
+        <div class="brand-title">MetaX Report</div>
+        <div class="brand-subtitle">A guided view of the OTF analysis</div>
+      </div>
+      <div class="nav-label">Report sections</div>
+      <button class="nav-button active" data-section-target="summary">
+        <span class="nav-icon">1</span>
+        <span class="nav-text"><span class="nav-title">Report Home</span><span class="nav-note">What was analyzed</span></span>
+      </button>
+      <button class="nav-button" data-section-target="overview">
+        <span class="nav-icon">2</span>
+        <span class="nav-text"><span class="nav-title">Overview</span><span class="nav-note">Annotation coverage</span></span>
+        <span class="count-pill">{{ figures_by_category.get("overview", [])|length }}</span>
+      </button>
+      <button class="nav-button" data-section-target="basic">
+        <span class="nav-icon">3</span>
+        <span class="nav-text"><span class="nav-title">Basic Plot</span><span class="nav-note">GUI plot families</span></span>
+        <span class="count-pill">{{ basic_plot_figure_count }}</span>
+      </button>
+      <button class="nav-button" data-section-target="statistics">
+        <span class="nav-icon">4</span>
+        <span class="nav-text"><span class="nav-title">Group Comparisons</span><span class="nav-note">Differences between groups</span></span>
+        <span class="count-pill">{{ stats|length }}</span>
+      </button>
+      <button class="nav-button" data-section-target="tables">
+        <span class="nav-icon">5</span>
+        <span class="nav-text"><span class="nav-title">Result Tables</span><span class="nav-note">Browse and export</span></span>
+        <span class="count-pill">{{ result_file_count }}</span>
+      </button>
+      <button class="nav-button" data-section-target="warnings">
+        <span class="nav-icon">6</span>
+        <span class="nav-text"><span class="nav-title">Run Notes</span><span class="nav-note">Warnings and logs</span></span>
+        <span class="count-pill">{{ warnings|length + errors|length }}</span>
+      </button>
+
+      <div class="side-summary">
+        <div class="side-summary-title">At a glance</div>
+        <div class="side-summary-row"><span>Samples</span><strong>{{ dataset_summary.get("n_samples", 0) }}</strong></div>
+        <div class="side-summary-row"><span>Peptides</span><strong>{{ dataset_summary.get("n_peptides", 0) }}</strong></div>
+        <div class="side-summary-row"><span>Result files</span><strong>{{ result_file_count }}</strong></div>
+        <div class="side-summary-row"><span>Figures</span><strong>{{ figures|length }}</strong></div>
+      </div>
+    </aside>
+
+    <main class="content">
+      <div class="report-hero">
+        <div>
+          <div class="eyebrow">Auto OTF report</div>
+          <h1>{{ title }}</h1>
+          <p class="hero-copy">This report organizes the analysis into review steps: understand the dataset, inspect overview charts, compare groups, review run notes, and export result tables.</p>
+        </div>
+        <div class="quick-links">
+          <a class="action-link" href="summary.json">Result summary</a>
+          <a class="action-link" href="config_used.yaml">Method settings</a>
+          <a class="action-link" href="logs/report.log">Run log</a>
+        </div>
+      </div>
+
+      <section id="summary" class="view-section active">
+        {% include "section_summary.html.j2" %}
+      </section>
+      <section id="overview" class="view-section">
+        {% include "section_overview.html.j2" %}
+      </section>
+      <section id="basic" class="view-section">
+        {% include "section_basic_plots.html.j2" %}
+      </section>
+      <section id="statistics" class="view-section">
+        {% include "section_statistics.html.j2" %}
+      </section>
+      <section id="tables" class="view-section">
+        {% include "section_tables.html.j2" %}
+      </section>
+      <section id="warnings" class="view-section">
+        {% include "section_warnings.html.j2" %}
+      </section>
+    </main>
+  </div>
+
+  <div class="modal" id="figure-modal" aria-hidden="true">
+    <div class="modal-panel" id="figure-modal-panel">
+      <div class="modal-header">
+        <div class="modal-title-area">
+          <h3 id="figure-modal-title">Figure</h3>
+          <div class="modal-tools" id="image-zoom-controls" hidden>
+            <button class="action-button" type="button" data-zoom-out>-</button>
+            <span class="zoom-label" id="image-zoom-label">100%</span>
+            <button class="action-button" type="button" data-zoom-in>+</button>
+            <button class="action-button" type="button" data-zoom-reset>Reset</button>
+          </div>
+        </div>
+        <button class="action-button" type="button" data-close-modal>Close</button>
+      </div>
+      <div class="image-stage" id="figure-image-stage">
+        <img id="figure-modal-image" alt="">
+      </div>
+      <iframe id="figure-modal-frame" title="Interactive figure" tabindex="0"></iframe>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll("[data-section-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.dataset.sectionTarget;
+        document.querySelectorAll("[data-section-target]").forEach((item) => item.classList.remove("active"));
+        document.querySelectorAll(".view-section").forEach((section) => section.classList.remove("active"));
+        button.classList.add("active");
+        document.getElementById(target).classList.add("active");
+      });
+    });
+
+    document.querySelectorAll("[data-tab-target]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const group = button.closest("[data-tab-group]");
+        const target = button.dataset.tabTarget;
+        const localButtons = Array.from(group.querySelectorAll("[data-tab-target]"))
+          .filter((item) => item.closest("[data-tab-group]") === group);
+        const localPanels = Array.from(group.querySelectorAll("[data-tab-panel]"))
+          .filter((panel) => panel.closest("[data-tab-group]") === group);
+        localButtons.forEach((item) => item.classList.remove("active"));
+        localPanels.forEach((panel) => panel.classList.remove("active"));
+        button.classList.add("active");
+        const panel = localPanels.find((item) => item.dataset.tabPanel === target);
+        if (panel) {
+          panel.classList.add("active");
+        }
+      });
+    });
+
+    document.querySelectorAll("[data-preview-src]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const card = button.closest(".artifact, .figure-tile");
+        const frame = card.querySelector(".preview-frame");
+        if (!frame.src) {
+          frame.src = button.dataset.previewSrc;
+        }
+        frame.classList.toggle("active");
+        const activeLabel = button.dataset.activeLabel || "Hide preview";
+        const inactiveLabel = button.dataset.inactiveLabel || "Preview";
+        button.textContent = frame.classList.contains("active") ? activeLabel : inactiveLabel;
+      });
+    });
+
+    document.querySelectorAll("[data-artifact-search]").forEach((input) => {
+      input.addEventListener("input", () => {
+        const scope = input.closest("[data-search-scope]");
+        const query = input.value.trim().toLowerCase();
+        scope.querySelectorAll("[data-search-item]").forEach((item) => {
+          item.style.display = item.dataset.searchItem.includes(query) ? "" : "none";
+        });
+      });
+    });
+
+    const modal = document.getElementById("figure-modal");
+    const modalPanel = document.getElementById("figure-modal-panel");
+    const modalImage = document.getElementById("figure-modal-image");
+    const modalImageStage = document.getElementById("figure-image-stage");
+    const modalFrame = document.getElementById("figure-modal-frame");
+    const modalTitle = document.getElementById("figure-modal-title");
+    const imageZoomControls = document.getElementById("image-zoom-controls");
+    const imageZoomLabel = document.getElementById("image-zoom-label");
+    let imageZoom = 1;
+    let imageFitZoom = 1;
+    function setModalMode(mode) {
+      modalPanel.classList.remove("image-preview", "interactive", "table-preview");
+      modalPanel.classList.add(mode);
+      imageZoomControls.hidden = mode !== "image-preview";
+    }
+    function setImageZoom(value) {
+      imageZoom = Math.min(3, Math.max(0.35, value));
+      if (modalImage.naturalWidth) {
+        modalImage.style.width = `${Math.max(1, modalImage.naturalWidth * imageZoom)}px`;
+      } else {
+        modalImage.style.width = `${imageZoom * 100}%`;
+      }
+      imageZoomLabel.textContent = `${Math.round(imageZoom * 100)}%`;
+    }
+    function fitImageToStage() {
+      if (!modalImage.naturalWidth || !modalImage.naturalHeight) {
+        setImageZoom(1);
+        return;
+      }
+      const stageWidth = Math.max(1, modalImageStage.clientWidth - 2);
+      const stageHeight = Math.max(1, modalImageStage.clientHeight - 2);
+      imageFitZoom = Math.min(stageWidth / modalImage.naturalWidth, stageHeight / modalImage.naturalHeight, 1);
+      setImageZoom(imageFitZoom);
+      modalImageStage.scrollTo({ top: 0, left: 0 });
+    }
+    function openFigureModal() {
+      modal.classList.add("active");
+      modal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("modal-open");
+    }
+    function closeFigureModal() {
+      modal.classList.remove("active");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("modal-open");
+      modalPanel.classList.remove("image-preview", "interactive", "table-preview");
+      imageZoomControls.hidden = true;
+      modalImage.src = "";
+      modalFrame.src = "";
+    }
+    document.querySelectorAll("[data-open-figure]").forEach((button) => {
+      button.addEventListener("click", () => {
+        setModalMode("image-preview");
+        modalFrame.src = "";
+        modalImage.src = button.dataset.openFigure;
+        modalImage.alt = button.dataset.figureTitle || "Figure";
+        modalTitle.textContent = button.dataset.figureTitle || "Figure";
+        openFigureModal();
+        if (modalImage.complete) {
+          requestAnimationFrame(fitImageToStage);
+        }
+      });
+    });
+    document.querySelectorAll("[data-open-interactive]").forEach((button) => {
+      button.addEventListener("click", () => {
+        modalImage.src = "";
+        setModalMode("interactive");
+        modalFrame.src = button.dataset.openInteractive;
+        modalFrame.title = button.dataset.figureTitle || "Interactive figure";
+        modalTitle.textContent = button.dataset.figureTitle || "Interactive figure";
+        openFigureModal();
+        requestAnimationFrame(() => modalFrame.focus());
+      });
+    });
+    document.querySelectorAll("[data-open-table]").forEach((button) => {
+      button.addEventListener("click", () => {
+        modalImage.src = "";
+        setModalMode("table-preview");
+        modalFrame.src = button.dataset.openTable;
+        modalFrame.title = button.dataset.figureTitle || "Result table";
+        modalTitle.textContent = button.dataset.figureTitle || "Result table";
+        openFigureModal();
+        requestAnimationFrame(() => modalFrame.focus());
+      });
+    });
+    document.querySelectorAll("[data-zoom-in]").forEach((button) => {
+      button.addEventListener("click", () => setImageZoom(imageZoom + 0.2));
+    });
+    document.querySelectorAll("[data-zoom-out]").forEach((button) => {
+      button.addEventListener("click", () => setImageZoom(imageZoom - 0.2));
+    });
+    document.querySelectorAll("[data-zoom-reset]").forEach((button) => {
+      button.addEventListener("click", () => setImageZoom(imageFitZoom || 1));
+    });
+    modalImage.addEventListener("load", fitImageToStage);
+    modalPanel.addEventListener("wheel", (event) => {
+      event.stopPropagation();
+    }, { passive: true });
+    modalFrame.addEventListener("load", () => {
+      if (modalPanel.classList.contains("interactive")) {
+        modalFrame.focus();
+      }
+    });
+    document.querySelectorAll("[data-close-modal]").forEach((button) => {
+      button.addEventListener("click", closeFigureModal);
+    });
+    modal.addEventListener("click", (event) => {
+      if (event.target === modal) {
+        closeFigureModal();
+      }
+    });
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && modal.classList.contains("active")) {
+        closeFigureModal();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/metax/report/templates/section_basic_plots.html.j2
+++ b/metax/report/templates/section_basic_plots.html.j2
@@ -1,0 +1,99 @@
+<div class="panel" data-tab-group data-search-scope>
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">GUI Basic Plot families</div>
+      <h2>Explore generated Basic Plot outputs</h2>
+      <p class="panel-help">Switch between the same plot families exposed in MetaX GUI. Each family is further split by result scope, so taxa, function, and OTF outputs are reviewed separately.</p>
+    </div>
+  </div>
+
+  {% if figures_by_kind %}
+    <div class="toolbar">
+      <input class="search-input" data-artifact-search type="search" placeholder="Search figures by taxa level, function, or plot type">
+      <span class="muted">{{ basic_plot_figure_count }} Basic Plot figures</span>
+    </div>
+    <div class="tab-strip">
+      {% for kind, items in figures_by_kind.items() %}
+        <button class="tab-button {% if loop.first %}active{% endif %}" data-tab-target="basic-{{ loop.index }}">{{ kind }} <span class="count-pill">{{ items|length }}</span></button>
+      {% endfor %}
+    </div>
+
+    {% for kind, items in figures_by_kind.items() %}
+      {% set family_index = loop.index %}
+      <div class="tab-panel {% if loop.first %}active{% endif %}" data-tab-panel="basic-{{ family_index }}">
+        {% set note = basic_plot_family_notes.get(kind) %}
+        {% if note %}
+          <div class="family-context">
+            <div class="family-note">
+              <div class="family-note-label">Interpretation</div>
+              <p>{{ note.purpose }} {{ note.read }}</p>
+            </div>
+          </div>
+        {% endif %}
+
+        {% set subgroups = basic_plot_subgroups.get(kind, {}) %}
+        <div class="subpanel" data-tab-group>
+          {% if subgroups|length > 1 %}
+            <div class="subgroup-summary">Choose a result scope before reviewing this plot family.</div>
+            <div class="tab-strip subtab-strip">
+              {% for subgroup, subitems in subgroups.items() %}
+                <button class="tab-button {% if loop.first %}active{% endif %}" data-tab-target="basic-{{ family_index }}-scope-{{ loop.index }}">{{ subgroup }} <span class="count-pill">{{ subitems|length }}</span></button>
+              {% endfor %}
+            </div>
+          {% endif %}
+
+          {% for subgroup, subitems in subgroups.items() %}
+            <div class="tab-panel {% if loop.first %}active{% endif %}" data-tab-panel="basic-{{ family_index }}-scope-{{ loop.index }}">
+              <div class="subgroup-heading">
+                <h3>{{ subgroup }}</h3>
+                <p class="muted">{{ subitems|length }} {{ kind }} figure{% if subitems|length != 1 %}s{% endif %}</p>
+              </div>
+              {% if subgroup == "OTF" %}
+                {% set function_groups = basic_plot_otf_function_groups.get(kind, {}) %}
+                <div class="function-panel-stack">
+                  {% for function_name, function_items in function_groups.items() %}
+                    <div class="function-panel">
+                      <div class="subgroup-heading">
+                        <h3>{{ function_name }}</h3>
+                        <p class="muted">{{ function_items|length }} OTF {{ kind }} figure{% if function_items|length != 1 %}s{% endif %}</p>
+                      </div>
+                      <div class="figure-grid">
+                        {% for figure in function_items %}
+                          {% include "figure_tile.html.j2" %}
+                        {% endfor %}
+                      </div>
+                    </div>
+                  {% else %}
+                    <div class="empty-state">No OTF figures were generated for this plot family.</div>
+                  {% endfor %}
+                </div>
+              {% else %}
+                <div class="figure-grid">
+                  {% for figure in subitems %}
+                    {% include "figure_tile.html.j2" %}
+                  {% endfor %}
+                </div>
+              {% endif %}
+            </div>
+          {% else %}
+            <div class="empty-state">No {{ kind }} figures were generated in this family.</div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="task-grid">
+      {% for title, text in [
+        ("Sample clustering", "PCA and correlation plots will summarize whether samples separate by metadata groups."),
+        ("Feature patterns", "Heatmaps will highlight the most abundant or most changed features."),
+        ("Composition", "Barplots, sunburst, treemap, and sankey views will summarize taxa and function composition."),
+        ("Diversity", "Alpha and beta diversity summaries will be shown when enabled.")
+      ] %}
+        <div class="task-card">
+          <div class="task-top"><div class="task-badge">{{ loop.index }}</div><h3>{{ title }}</h3></div>
+          <p class="muted">{{ text }}</p>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/metax/report/templates/section_overview.html.j2
+++ b/metax/report/templates/section_overview.html.j2
@@ -1,0 +1,33 @@
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Overview charts</div>
+      <h2>Quick visual checks</h2>
+      <p class="panel-help">These charts help users understand whether the dataset has broad taxonomic coverage and usable function annotations before looking at detailed tables.</p>
+    </div>
+  </div>
+
+  {% if overview_figures_by_group %}
+    <div class="section-context">
+      <strong>What to check first:</strong>
+      taxonomy coverage indicates whether peptides are assigned across expected taxa levels; function annotation coverage shows which functional columns are usable for downstream tables and plots.
+    </div>
+    <div class="function-panel-stack">
+      {% for group_name, group_figures in overview_figures_by_group.items() %}
+        <div class="function-panel">
+          <div class="subgroup-heading">
+            <h3>{{ group_name }}</h3>
+            <span class="muted">{{ group_figures|length }} charts</span>
+          </div>
+          <div class="figure-grid">
+            {% for figure in group_figures %}
+              {% include "figure_tile.html.j2" %}
+            {% endfor %}
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="empty-state">No overview charts were generated for this run.</div>
+  {% endif %}
+</div>

--- a/metax/report/templates/section_statistics.html.j2
+++ b/metax/report/templates/section_statistics.html.j2
@@ -1,0 +1,60 @@
+<div class="panel" data-tab-group data-search-scope>
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Group comparisons</div>
+      <h2>Visual comparison summaries</h2>
+      <p class="panel-help">Group comparison TSV files are available in Result Tables. This page focuses on visual outputs generated from those comparison results.</p>
+    </div>
+  </div>
+
+  {% if differential_figures_by_scope %}
+    <div class="section-context">
+      <strong>Reading differential plots:</strong>
+      volcano plots summarize effect size and adjusted significance for each group-vs-control comparison. Heatmaps are only shown when the GUI heatmap function finds significant features after filtering.
+    </div>
+    <div class="toolbar">
+      <input class="search-input" data-artifact-search type="search" placeholder="Search differential figures by taxa level, function, comparison, or plot type">
+      <span class="muted">{{ figures_by_category.get("differential", [])|length }} differential figures</span>
+    </div>
+    <div class="tab-strip">
+      {% for scope, plot_groups in differential_figures_by_scope.items() %}
+        {% set scope_count = namespace(value=0) %}
+        {% for plot_type, items in plot_groups.items() %}
+          {% set scope_count.value = scope_count.value + items|length %}
+        {% endfor %}
+        <button class="tab-button {% if loop.first %}active{% endif %}" data-tab-target="diff-{{ loop.index }}">{{ scope }} <span class="count-pill">{{ scope_count.value }}</span></button>
+      {% endfor %}
+    </div>
+
+    {% for scope, plot_groups in differential_figures_by_scope.items() %}
+      <div class="tab-panel {% if loop.first %}active{% endif %}" data-tab-panel="diff-{{ loop.index }}">
+        <div class="function-panel-stack">
+          {% for plot_type, items in plot_groups.items() %}
+            <div class="function-panel">
+              <div class="subgroup-heading">
+                <h3>{{ plot_type }}</h3>
+                <p class="muted">{{ items|length }} {{ scope }} differential figure{% if items|length != 1 %}s{% endif %}</p>
+              </div>
+              <div class="figure-grid">
+                {% for figure in items %}
+                  {% include "figure_tile.html.j2" %}
+                {% endfor %}
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="task-grid">
+      <div class="task-card">
+        <div class="task-top"><div class="task-badge">A</div><h3>Comparison result tables</h3></div>
+        <p class="muted">Open Result Tables to inspect ANOVA, t-test, Dunnett, or group-vs-control result TSV files.</p>
+      </div>
+      <div class="task-card">
+        <div class="task-top"><div class="task-badge">B</div><h3>Differential figures</h3></div>
+        <p class="muted">Volcano plots and significant-feature heatmaps appear here when comparison results and significant features are available.</p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/metax/report/templates/section_summary.html.j2
+++ b/metax/report/templates/section_summary.html.j2
@@ -1,0 +1,120 @@
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Report home</div>
+      <h2>Your analysis at a glance</h2>
+      <p class="panel-help">Use this page to confirm what was analyzed, then move through the report from charts to downloadable results.</p>
+    </div>
+    <div class="chip-row">
+      {% for level in selected_taxa_levels %}
+        <span class="chip">Taxa level {{ level }}</span>
+      {% endfor %}
+      {% for function_name in selected_function_columns %}
+        <span class="chip">{{ function_name }}</span>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="metric-grid">
+    <div class="metric primary">
+      <div class="label">Samples analyzed</div>
+      <div class="value">{{ dataset_summary.get("n_samples", 0) }}</div>
+      <div class="hint">Samples matched to the metadata table</div>
+    </div>
+    <div class="metric blue">
+      <div class="label">Peptides</div>
+      <div class="value">{{ dataset_summary.get("n_peptides", 0) }}</div>
+      <div class="hint">Rows kept after basic input loading</div>
+    </div>
+    <div class="metric coral">
+      <div class="label">OTF tables</div>
+      <div class="value">{{ dataset_summary.get("otf_counts", [])|length }}</div>
+      <div class="hint">Feature counts are listed for every computed taxa-function table</div>
+    </div>
+    <div class="metric gold">
+      <div class="label">Report outputs</div>
+      <div class="value">{{ run_summary.n_tables + run_summary.n_figures }}</div>
+      <div class="hint">{{ run_summary.n_tables }} tables and {{ run_summary.n_figures }} figures</div>
+    </div>
+  </div>
+
+  {% if dataset_summary.get("otf_counts") %}
+    <div class="section-context" style="margin-top: 16px;">
+      <strong>OTF feature counts:</strong>
+      each card shows the number of taxa-function links generated for one taxa level and function annotation combination.
+    </div>
+    <div class="metric-grid">
+      {% for item in dataset_summary.get("otf_counts", []) %}
+        <div class="metric">
+          <div class="label">{{ item.taxa_level }} / {{ item.function_column }}</div>
+          <div class="value">{{ item.n_features }}</div>
+          <div class="hint">{{ item.title }}</div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>
+
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Recommended review path</div>
+      <h2>Where to start</h2>
+    </div>
+  </div>
+  <div class="task-grid">
+    <div class="task-card">
+      <div class="task-top"><div class="task-badge">1</div><h3>Check the dataset</h3></div>
+      <p class="muted">Confirm sample count, selected taxa levels, and function annotation columns before interpreting the results.</p>
+    </div>
+    <div class="task-card">
+      <div class="task-top"><div class="task-badge">2</div><h3>Review overview charts</h3></div>
+      <p class="muted">Use the chart section for a quick sense of taxonomic coverage and function annotation quality.</p>
+    </div>
+    <div class="task-card">
+      <div class="task-top"><div class="task-badge">3</div><h3>Browse result tables</h3></div>
+      <p class="muted">Preview paginated tables in the browser, then export the full TSV files for downstream work.</p>
+    </div>
+    <div class="task-card">
+      <div class="task-top"><div class="task-badge">4</div><h3>Look for run notes</h3></div>
+      <p class="muted">Warnings explain skipped optional steps or input differences that may affect interpretation.</p>
+    </div>
+  </div>
+</div>
+
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Input and settings</div>
+      <h2>What was used</h2>
+      <p class="panel-help">The detailed method settings are saved with the report so the analysis can be reproduced.</p>
+    </div>
+    <a class="action-link" href="config_used.yaml">Download method settings</a>
+  </div>
+  <div class="metric-grid">
+    <div class="metric">
+      <div class="label">OTF table</div>
+      <div class="value">Provided</div>
+      <div class="hint">{{ run_summary.otf_file }}</div>
+    </div>
+    <div class="metric">
+      <div class="label">Metadata table</div>
+      <div class="value">{{ "Provided" if run_summary.meta_file != "Generated internally" else "Generated" }}</div>
+      <div class="hint">{{ run_summary.meta_file }}</div>
+    </div>
+    <div class="metric">
+      <div class="label">Grouping column</div>
+      <div class="value">{{ run_summary.group_column }}</div>
+      <div class="hint">Used for group summaries and comparisons when available</div>
+    </div>
+    <div class="metric">
+      <div class="label">Control group</div>
+      <div class="value">{{ run_summary.control_group }}</div>
+      <div class="hint">Used for group-vs-control testing when available</div>
+    </div>
+  </div>
+  <details class="config-block">
+    <summary>Show full method settings</summary>
+    <pre>{{ config_yaml }}</pre>
+  </details>
+</div>

--- a/metax/report/templates/section_tables.html.j2
+++ b/metax/report/templates/section_tables.html.j2
@@ -1,0 +1,68 @@
+<div class="panel" data-tab-group data-search-scope>
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Result files</div>
+      <h2>Browse downloadable tables and comparison results</h2>
+      <p class="panel-help">Raw abundance tables, QC summaries, and group comparison TSVs are collected here. Click Preview for a paginated in-page view, or Export when you need the complete TSV file.</p>
+    </div>
+  </div>
+
+  {% if result_files %}
+    <div class="toolbar">
+      <input class="search-input" data-artifact-search type="search" placeholder="Search tables by name, taxa level, function, comparison, or result type">
+      <span class="muted">{{ result_file_count }} downloadable result files</span>
+    </div>
+
+    <div class="tab-strip">
+      {% for category, items in result_files_by_category.items() %}
+        {% if category == "taxa" %}
+          {% set label = "Taxa abundance" %}
+        {% elif category == "function" %}
+          {% set label = "Function abundance" %}
+        {% elif category == "otf" %}
+          {% set label = "OTF tables" %}
+        {% elif category == "qc" %}
+          {% set label = "Quality checks" %}
+        {% elif category == "comparison_taxa" %}
+          {% set label = "Taxa comparisons" %}
+        {% elif category == "comparison_function" %}
+          {% set label = "Function comparisons" %}
+        {% elif category == "comparison_otf" %}
+          {% set label = "OTF comparisons" %}
+        {% else %}
+          {% set label = category|replace("_", " ")|capitalize %}
+        {% endif %}
+        <button class="tab-button {% if loop.first %}active{% endif %}" data-tab-target="tables-{{ category }}">{{ label }} <span class="count-pill">{{ items|length }}</span></button>
+      {% endfor %}
+    </div>
+
+    {% for category, items in result_files_by_category.items() %}
+      <div class="tab-panel {% if loop.first %}active{% endif %}" data-tab-panel="tables-{{ category }}">
+        <div class="artifact-list">
+          {% for item in items %}
+            <div class="artifact" data-search-item="{{ (item.title ~ ' ' ~ item.description ~ ' ' ~ item.relative_path)|lower }}">
+              <div class="artifact-row">
+                <div>
+                  <div class="artifact-title">{{ item.rich_title|default(item.title)|safe }}</div>
+                  {% if item.description %}<div class="artifact-meta">{{ item.description }}</div>{% endif %}
+                  <div class="file-path">{{ item.relative_path }}</div>
+                </div>
+                <div class="artifact-actions">
+                  {% if item.preview_relative_path %}
+                    <button class="action-button primary" data-preview-src="{{ item.preview_relative_path }}" data-active-label="Hide preview" data-inactive-label="Preview">Preview</button>
+                  {% endif %}
+                  <a class="action-link" href="{{ item.relative_path }}">Export</a>
+                </div>
+              </div>
+              {% if item.preview_relative_path %}
+                <iframe class="preview-frame" title="{{ item.title }} preview"></iframe>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="empty-state">No result files were generated for this run.</div>
+  {% endif %}
+</div>

--- a/metax/report/templates/section_taxa_function.html.j2
+++ b/metax/report/templates/section_taxa_function.html.j2
@@ -1,0 +1,68 @@
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Taxa-function links</div>
+      <h2>Which taxa carry which functions</h2>
+      <p class="panel-help">The OTF tables in Result Tables provide the underlying links. Interactive networks and sankey summaries will appear here as the advanced plotting phase is added.</p>
+    </div>
+  </div>
+
+  {% set tf_figures = figures_by_category.get("taxa_function", []) %}
+  {% if tf_figures %}
+    <div class="section-context">
+      <strong>What this section means:</strong>
+      taxa-function figures are built from OTF tables. They show which taxa are linked to major functional annotations and whether those links are concentrated in specific groups or broad across the dataset.
+    </div>
+    <div class="figure-grid">
+      {% for figure in tf_figures %}
+        <div class="figure-tile">
+          <div class="artifact-title">{{ figure.rich_title|default(figure.title)|safe }}</div>
+          {% if figure.description %}
+            <details class="figure-meta-details">
+              <summary>Details</summary>
+              <div class="artifact-meta">{{ figure.description }}</div>
+            </details>
+          {% endif %}
+          {% if figure.relative_path.lower().endswith(".png") %}
+            <img src="{{ figure.relative_path }}" alt="{{ figure.title }}">
+            <div class="artifact-actions">
+              <button class="action-button primary" data-open-figure="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">View larger</button>
+              <a class="action-link" href="{{ figure.relative_path }}">Open image</a>
+            </div>
+          {% elif figure.relative_path.lower().endswith(".html") %}
+            <button class="interactive-thumb" type="button" data-open-interactive="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">
+              <span class="interactive-mark">HTML</span>
+              <span class="interactive-copy">
+                <strong>Interactive plot</strong>
+                <span>Preview in a large viewer</span>
+              </span>
+            </button>
+            <div class="artifact-actions">
+              <button class="action-button primary" data-open-interactive="{{ figure.relative_path }}" data-figure-title="{{ figure.title }}">Preview</button>
+              <a class="action-link" href="{{ figure.relative_path }}">Export</a>
+            </div>
+          {% else %}
+            <div class="artifact-actions">
+              <a class="action-link" href="{{ figure.relative_path }}">Open figure</a>
+            </div>
+          {% endif %}
+        </div>
+      {% endfor %}
+    </div>
+  {% else %}
+    <div class="task-grid">
+      <div class="task-card">
+        <div class="task-top"><div class="task-badge">N</div><h3>Network view</h3></div>
+        <p class="muted">Will show major taxa-function connections with top-N filtering.</p>
+      </div>
+      <div class="task-card">
+        <div class="task-top"><div class="task-badge">S</div><h3>Sankey summary</h3></div>
+        <p class="muted">Will show how dominant taxa connect to dominant functions.</p>
+      </div>
+      <div class="task-card">
+        <div class="task-top"><div class="task-badge">H</div><h3>OTF heatmap</h3></div>
+        <p class="muted">Will highlight the strongest taxa-function abundance patterns.</p>
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/metax/report/templates/section_warnings.html.j2
+++ b/metax/report/templates/section_warnings.html.j2
@@ -1,0 +1,66 @@
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Run notes</div>
+      <h2>Items that may need attention</h2>
+      <p class="panel-help">Warnings do not necessarily mean the report failed. They explain skipped optional steps, input differences, or analysis choices that users should know before interpreting results.</p>
+    </div>
+    <a class="action-link" href="logs/report.log">Open full log</a>
+  </div>
+
+  <div class="section-context">
+    <strong>Run context for these notes:</strong>
+    group column {{ warning_run_info.group_meta }},
+    control {{ warning_run_info.control_group }},
+    taxa levels {{ warning_run_info.taxa_levels }},
+    functions {{ warning_run_info.function_columns }},
+    top-N {{ warning_run_info.top_n }},
+    heatmap top-N {{ warning_run_info.heatmap_top_n }},
+    alpha {{ warning_run_info.alpha }},
+    log2FC cutoff {{ warning_run_info.log2fc_cutoff }}.
+  </div>
+
+  {% if warnings %}
+    {% for warning in warnings %}
+      <div class="message">
+        <strong>Warning</strong>
+        <div>{{ warning.message }}</div>
+        {% if warning.source %}<div class="artifact-meta">Source: {{ warning.source }}</div>{% endif %}
+        {% if warning.details %}
+          <details class="figure-meta-details">
+            <summary>Run details</summary>
+            <div class="artifact-meta">
+              {% for key, value in warning.details.items() %}
+                <div><strong>{{ key }}:</strong> {{ value }}</div>
+              {% endfor %}
+            </div>
+          </details>
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="empty-state">No warnings were recorded for this run.</div>
+  {% endif %}
+
+  {% if errors %}
+    <h3>Errors</h3>
+    {% for error in errors %}
+      <div class="message error">
+        <strong>Error</strong>
+        <div>{{ error.message }}</div>
+        {% if error.source %}<div class="artifact-meta">Source: {{ error.source }}</div>{% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>
+
+<div class="panel">
+  <div class="panel-header">
+    <div>
+      <div class="panel-kicker">Export</div>
+      <h2>Use the results outside this report</h2>
+      <p class="panel-help">The summary file lists every generated table, figure, and note in a machine-readable format.</p>
+    </div>
+    <a class="action-link" href="summary.json">Download result summary</a>
+  </div>
+</div>

--- a/metax/report/workflow.py
+++ b/metax/report/workflow.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from metax.taxafunc_analyzer.analyzer import TaxaFuncAnalyzer
+
+from .config import AutoReportConfig, save_config_used
+from .html_report import HtmlReportBuilder
+from .paths import ReportPaths
+from .plot_builder import PlotBuilder
+from .registry import ResultRegistry
+from .stats_builder import StatsBuilder
+from .table_builder import TableBuilder, VALID_TAXA_LEVELS
+
+
+@dataclass
+class ReportResult:
+    output_dir: Path
+    index_html_path: Path
+    summary_json_path: Path
+    registry: ResultRegistry
+
+
+@dataclass
+class ReportContext:
+    config: AutoReportConfig
+    paths: ReportPaths
+    registry: ResultRegistry
+    logger: logging.Logger
+    tfa: TaxaFuncAnalyzer
+    generated_tables: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    generated_stats: list[dict[str, Any]] = field(default_factory=list)
+    function_columns: list[str] = field(default_factory=list)
+    taxa_levels: list[str] = field(default_factory=list)
+    dataset_summary: dict[str, Any] = field(default_factory=dict)
+
+
+class AutoOTFReport:
+    def __init__(self, config: AutoReportConfig):
+        self.config = config
+        self._validation_warnings: list[dict[str, Any]] = []
+
+    def run(self) -> ReportResult:
+        self._validate_input_files()
+        output_was_nonempty = self._output_was_nonempty()
+        paths = ReportPaths(self.config.report.output_dir)
+        self._prepare_output_dir(paths)
+        logger = self._setup_logging(paths)
+        registry = ResultRegistry()
+        for warning in self._validation_warnings:
+            registry.add_warning(warning["message"], warning["source"], details=warning.get("details"))
+        if output_was_nonempty and not self.config.report.overwrite:
+            registry.add_warning(
+                "Output directory already contained files. Existing report files may be overwritten.",
+                "AutoOTFReport",
+                details={
+                    "output_dir": self.config.report.output_dir,
+                    "overwrite": self.config.report.overwrite,
+                },
+            )
+
+        logger.info("Starting MetaX Auto OTF report")
+        logger.info("OTF path: %s", self.config.input.otf_path)
+        logger.info("Meta path: %s", self.config.input.meta_path)
+        logger.info("Output directory: %s", paths.output_dir)
+        logger.info("Config: %s", self.config.to_dict())
+        save_config_used(self.config, paths.output_dir)
+
+        try:
+            with self._redirect_backend_output(logger):
+                tfa = self._init_analyzer()
+                context = ReportContext(
+                    config=self.config,
+                    paths=paths,
+                    registry=registry,
+                    logger=logger,
+                    tfa=tfa,
+                )
+                self._validate_analyzer_context(context)
+
+                TableBuilder(context).build_all()
+                self._ensure_core_tables(context)
+                StatsBuilder(context).run_all()
+                PlotBuilder(context).plot_all()
+
+            context.dataset_summary = self._dataset_summary(context)
+            index_html_path = HtmlReportBuilder(context).render()
+            registry.finish()
+            summary_json_path = self._save_summary(context)
+            logger.info("Report finished: %s", index_html_path)
+            return ReportResult(
+                output_dir=paths.output_dir,
+                index_html_path=index_html_path,
+                summary_json_path=summary_json_path,
+                registry=registry,
+            )
+        except Exception as exc:
+            registry.add_error(str(exc), "AutoOTFReport")
+            logger.exception("Fatal report failure")
+            raise
+
+    def _validate_input_files(self) -> None:
+        input_config = self.config.input
+        if not input_config.otf_path:
+            raise ValueError("OTF path is required.")
+        otf_path = Path(input_config.otf_path)
+        if not otf_path.exists():
+            raise FileNotFoundError(f"OTF file does not exist: {otf_path}")
+        if not otf_path.is_file():
+            raise ValueError(f"OTF path is not a file: {otf_path}")
+
+        if input_config.meta_path:
+            meta_path = Path(input_config.meta_path)
+            if not meta_path.exists():
+                raise FileNotFoundError(f"Meta file does not exist: {meta_path}")
+            if not meta_path.is_file():
+                raise ValueError(f"Meta path is not a file: {meta_path}")
+            self._validate_meta_samples_match(otf_path, meta_path)
+
+        taxa_levels = self.config.tables.taxa_levels
+        if taxa_levels != ["all"]:
+            invalid = [level for level in taxa_levels if level not in VALID_TAXA_LEVELS]
+            if invalid:
+                raise ValueError(f"Invalid taxa level(s): {invalid}. Valid levels: {sorted(VALID_TAXA_LEVELS)}")
+
+    def _validate_meta_samples_match(self, otf_path: Path, meta_path: Path) -> None:
+        otf_samples = set(self._detect_otf_samples(otf_path))
+        if not otf_samples:
+            raise ValueError(
+                f"No sample columns detected in OTF table using prefix [{self.config.input.sample_col_prefix}]."
+            )
+        meta = pd.read_csv(meta_path, sep="\t", keep_default_na=False, dtype=str)
+        if meta.empty:
+            raise ValueError(f"Meta table is empty: {meta_path}")
+        sample_col = meta.columns[0]
+        meta_samples = {
+            self._normalize_sample_name(value)
+            for value in meta[sample_col].astype(str).tolist()
+            if str(value).strip()
+        }
+        missing_in_meta = sorted(otf_samples - meta_samples)
+        missing_in_otf = sorted(meta_samples - otf_samples)
+        if missing_in_otf:
+            raise ValueError(
+                "Samples in OTF and meta table do not match. "
+                f"Missing in OTF: {missing_in_otf}"
+            )
+        if missing_in_meta:
+            self._validation_warnings.append(
+                {
+                    "message": (
+                        "OTF table contains samples that are not present in the meta table. "
+                        f"These samples will not be used by TaxaFuncAnalyzer: {missing_in_meta}"
+                    ),
+                    "source": "AutoOTFReport",
+                    "details": {
+                        "otf_path": str(otf_path),
+                        "meta_path": str(meta_path),
+                        "sample_col_prefix": self.config.input.sample_col_prefix,
+                        "missing_in_meta": missing_in_meta,
+                        "n_missing_in_meta": len(missing_in_meta),
+                        "n_otf_samples": len(otf_samples),
+                        "n_meta_samples": len(meta_samples),
+                    },
+                }
+            )
+
+    def _detect_otf_samples(self, otf_path: Path) -> list[str]:
+        header = pd.read_csv(otf_path, sep="\t", nrows=0).columns.tolist()
+        prefix = self.config.input.sample_col_prefix.strip()
+        if not prefix:
+            raise ValueError("sample_col_prefix must be provided for OTF input.")
+        normalized_columns = [column.replace(" ", "_") for column in header]
+        sample_columns = [
+            column for column in normalized_columns if column.startswith(prefix) and column != prefix
+        ]
+        return [self._normalize_sample_name(column) for column in sample_columns]
+
+    def _normalize_sample_name(self, value: str) -> str:
+        prefix = self.config.input.sample_col_prefix.strip()
+        sample = str(value).strip().replace(" ", "_")
+        if prefix and sample.startswith(prefix):
+            sample = sample.replace(prefix, "", 1)
+        if sample.startswith("_"):
+            sample = sample[1:]
+        return sample
+
+    def _output_was_nonempty(self) -> bool:
+        output_dir = Path(self.config.report.output_dir)
+        return output_dir.exists() and output_dir.is_dir() and any(output_dir.iterdir())
+
+    def _prepare_output_dir(self, paths: ReportPaths) -> None:
+        if paths.output_dir.exists() and not paths.output_dir.is_dir():
+            raise ValueError(f"Output path exists but is not a directory: {paths.output_dir}")
+        if paths.output_dir.exists() and self.config.report.overwrite:
+            self._clear_previous_report(paths.output_dir)
+        paths.create()
+        test_path = paths.output_dir / ".write_test"
+        try:
+            test_path.write_text("ok", encoding="utf-8")
+            test_path.unlink()
+        except OSError as exc:
+            raise OSError(f"Output directory is not writable: {paths.output_dir}") from exc
+
+    def _clear_previous_report(self, output_dir: Path) -> None:
+        for name in ["tables", "stats", "figures", "assets", "logs"]:
+            path = output_dir / name
+            if path.exists():
+                shutil.rmtree(path)
+        for name in ["index.html", "config_used.yaml", "summary.json"]:
+            path = output_dir / name
+            if path.exists():
+                path.unlink()
+
+    def _setup_logging(self, paths: ReportPaths) -> logging.Logger:
+        logger = logging.getLogger(f"metax.report.auto_otf.{id(self)}")
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+        logger.handlers.clear()
+
+        formatter = logging.Formatter(
+            fmt="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        file_handler = logging.FileHandler(paths.logs_dir / "report.log", encoding="utf-8")
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+        return logger
+
+    @contextmanager
+    def _redirect_backend_output(self, logger: logging.Logger):
+        writer = _LoggerWriter(logger, logging.INFO)
+        with redirect_stdout(writer), redirect_stderr(writer):
+            yield
+
+    def _init_analyzer(self) -> TaxaFuncAnalyzer:
+        config = self.config.input
+        tfa = TaxaFuncAnalyzer(
+            df_path=config.otf_path,
+            meta_path=config.meta_path,
+            peptide_col_name=config.peptide_col_name,
+            protein_col_name=config.protein_col_name,
+            sample_col_prefix=config.sample_col_prefix,
+            any_df_mode=config.any_df_mode,
+            custom_col_name=config.custom_col_name or "Custom",
+        )
+        if config.meta_path is None:
+            sample_list = list(tfa.sample_list or [])
+            tfa.meta_df = pd.DataFrame(
+                {
+                    "Sample": sample_list,
+                    "AutoGroup": ["All"] * len(sample_list),
+                    "Sample_Name": sample_list,
+                }
+            )
+        return tfa
+
+    def _validate_analyzer_context(self, context: ReportContext) -> None:
+        tfa = context.tfa
+        if not tfa.sample_list:
+            raise ValueError("No sample columns detected after initializing TaxaFuncAnalyzer.")
+        if tfa.meta_df is None or tfa.meta_df.empty:
+            raise ValueError("Meta table is empty after initializing TaxaFuncAnalyzer.")
+
+        self._validate_meta_column(context.config.preprocessing.detection_by_group, tfa, "detection_by_group")
+        self._validate_meta_column(context.config.preprocessing.handle_by_group, tfa, "handle_by_group")
+        self._validate_meta_column(context.config.preprocessing.batch_meta, tfa, "batch_meta")
+
+        group_meta = context.config.analysis.group_meta
+        if group_meta:
+            if group_meta not in tfa.meta_df.columns:
+                raise ValueError(f"group_meta [{group_meta}] is not in meta table columns: {list(tfa.meta_df.columns)}")
+            tfa.set_group(group_meta)
+
+            control_group = context.config.analysis.control_group
+            if control_group:
+                groups = set(tfa.meta_df[group_meta].astype(str))
+                if control_group not in groups:
+                    raise ValueError(
+                        f"control_group [{control_group}] is not present in group_meta [{group_meta}]. "
+                        f"Available groups: {sorted(groups)}"
+                    )
+        elif context.config.analysis.control_group:
+            raise ValueError("control_group was provided, but group_meta is not set.")
+
+    def _validate_meta_column(self, column: str | None, tfa: TaxaFuncAnalyzer, field_name: str) -> None:
+        if column in [None, "None", ""]:
+            return
+        if column not in tfa.meta_df.columns:
+            raise ValueError(f"{field_name} [{column}] is not in meta table columns: {list(tfa.meta_df.columns)}")
+
+    def _ensure_core_tables(self, context: ReportContext) -> None:
+        core_count = sum(
+            len(context.generated_tables.get(table_type, []))
+            for table_type in ["taxa", "function", "otf", "protein"]
+        )
+        if core_count == 0:
+            raise RuntimeError("No core analysis tables were generated.")
+
+    def _dataset_summary(self, context: ReportContext) -> dict[str, Any]:
+        group_meta = context.config.analysis.group_meta
+        if group_meta and group_meta in context.tfa.meta_df.columns:
+            n_groups = int(context.tfa.meta_df[group_meta].nunique())
+        else:
+            n_groups = 1
+
+        return {
+            "n_samples": len(context.tfa.sample_list or []),
+            "n_groups": n_groups,
+            "n_peptides": int(context.tfa.original_df.shape[0]),
+            "n_taxa": self._first_table_rows(context, "taxa"),
+            "n_functions": self._first_table_rows(context, "function"),
+            "n_otfs": self._first_table_rows(context, "otf"),
+            "otf_counts": self._otf_table_counts(context),
+        }
+
+    def _first_table_rows(self, context: ReportContext, table_type: str) -> int:
+        tables = context.generated_tables.get(table_type, [])
+        if not tables:
+            return 0
+        return int(tables[0]["df"].shape[0])
+
+    def _otf_table_counts(self, context: ReportContext) -> list[dict[str, Any]]:
+        counts: list[dict[str, Any]] = []
+        for artifact in context.generated_tables.get("otf", []):
+            counts.append(
+                {
+                    "key": artifact.get("key"),
+                    "title": artifact.get("title"),
+                    "taxa_level": artifact.get("taxa_level"),
+                    "function_column": artifact.get("function_column"),
+                    "n_features": int(artifact["df"].shape[0]),
+                }
+            )
+        return counts
+
+    def _save_summary(self, context: ReportContext) -> Path:
+        path = context.paths.output_dir / "summary.json"
+        registry_dict = context.registry.to_dict()
+        summary = {
+            "input": context.config.input.__dict__,
+            "config": context.config.to_dict(),
+            "dataset_summary": context.dataset_summary,
+            "outputs": {
+                "tables": registry_dict["tables"],
+                "figures": registry_dict["figures"],
+                "stats": registry_dict["stats"],
+                "html": registry_dict["html"],
+            },
+            "warnings": registry_dict["warnings"],
+            "errors": registry_dict["errors"],
+            "runtime": registry_dict["runtime"],
+        }
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(summary, handle, indent=2)
+        context.logger.info("Saved summary JSON: %s", path)
+        return path
+
+
+class _LoggerWriter:
+    def __init__(self, logger: logging.Logger, level: int):
+        self.logger = logger
+        self.level = level
+        self._buffer = ""
+
+    def write(self, message: str) -> int:
+        if not message:
+            return 0
+        self._buffer += message.replace("\r", "\n")
+        while "\n" in self._buffer:
+            line, self._buffer = self._buffer.split("\n", 1)
+            line = line.strip()
+            if line:
+                self.logger.log(self.level, line)
+        return len(message)
+
+    def flush(self) -> None:
+        line = self._buffer.strip()
+        if line:
+            self.logger.log(self.level, line)
+        self._buffer = ""

--- a/metax/taxafunc_ploter/heatmap_plot.py
+++ b/metax/taxafunc_ploter/heatmap_plot.py
@@ -41,6 +41,13 @@ class HeatmapPlot:
         else:
             return 'top'
 
+    def _heatmap_right_margin(self, n_columns: int) -> float:
+        if n_columns <= 3:
+            return 0.34
+        if n_columns <= 8:
+            return 0.42
+        return 0.5
+
     def rename_taxa(self, df):
         first_index = df.index[0]
         index_list = df.index.tolist()
@@ -145,7 +152,7 @@ class HeatmapPlot:
             sns_params = {
                 'center': 0 if data_include_negative_and_positive else None,
                 "cmap": cmap,
-                "linewidths": 0.01, 
+                "linewidths": 0, 
                 "linecolor": None if linecolor == 'none' else linecolor,
                 "dendrogram_ratio": (0.1, 0.2),
                 "figsize": fig_size if return_type == 'fig' else None,
@@ -306,7 +313,7 @@ class HeatmapPlot:
             sns_params = {
                 "center": 0 if data_include_negative_and_positive else None,
                 "cmap": cmap,
-                "linewidths": 0.01, 
+                "linewidths": 0, 
                 "linecolor": None if linecolor == 'none' else linecolor,
                 "figsize": fig_size if return_type == 'fig' else None,
                 "cbar_kws": {"label": "Intensity", "shrink": 0.5},
@@ -359,7 +366,7 @@ class HeatmapPlot:
             cbar.ax.yaxis.set_ticks_position('left')
             cbar.ax.yaxis.set_label_position('left')
 
-            plt.subplots_adjust(left=0.05, bottom=0.11, right=0.5, top=0.96, wspace=0.01, hspace=0.01)
+            plt.subplots_adjust(left=0.05, bottom=0.11, right=self._heatmap_right_margin(len(mat.columns)), top=0.96, wspace=0.01, hspace=0.01)
             
             plt.tight_layout()
             plt.show()
@@ -379,7 +386,7 @@ class HeatmapPlot:
                     cmap:str|None = None, rename_taxa:bool = True, font_size:int = 10,
                     show_all_labels:tuple = (False, False), scale_method:str = 'maxmin', return_type:str = 'fig',
                     sample_to_group_dict:dict|None = None, x_filter_list: list = [], y_filter_list: list = [],
-                    filter_by_regex:bool = False, linecolor:str = 'none', linewidths:float = 0.01):
+                    filter_by_regex:bool = False, linecolor:str = 'none', linewidths:float = 0):
 
 
         df = self.filter_data_by_x_y(df, x_filter_list, y_filter_list, filter_by_regex)
@@ -604,7 +611,7 @@ class HeatmapPlot:
                 "cmap": cmap,
                 "figsize": fig_size,
                 "norm": norm,
-                "linewidths": 0.01, 
+                "linewidths": 0, 
                 "linecolor": None if linecolor == 'none' else linecolor,
                 "dendrogram_ratio": (0.1, 0.2),
                 "col_cluster": col_cluster,
@@ -751,7 +758,7 @@ class HeatmapPlot:
                 "cmap": cmap,
                 "figsize": fig_size,
                 "norm": norm,
-                "linewidths": 0.01, 
+                "linewidths": 0, 
                 "linecolor": None if linecolor == 'none' else linecolor,
                 "dendrogram_ratio": (0.1, 0.2),
                 "cbar_kws": {"label": "t-statistic", "shrink": 0.5},
@@ -786,7 +793,7 @@ class HeatmapPlot:
             cbar.ax.yaxis.set_ticks_position('left')
             cbar.ax.yaxis.set_label_position('left')
             
-            plt.subplots_adjust(left=0.05, bottom=0.15, right=0.5, top=0.96, wspace=0.01, hspace=0.01)
+            plt.subplots_adjust(left=0.05, bottom=0.15, right=self._heatmap_right_margin(len(dft.columns)), top=0.96, wspace=0.01, hspace=0.01)
 
             plt.tight_layout()
             plt.show()
@@ -951,4 +958,3 @@ class HeatmapPlot:
                     df = df / max_val
 
         return df
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "adjustText>=1.1.1",
     "openpyxl",
     "pyproject-toml>=0.0.10",
+    "PyYAML>=6.0",
+    "Jinja2>=3.1",
     "statsmodels",
     "seaborn>=0.13.2",
     "numba>=0.60.0",
@@ -48,6 +50,7 @@ dependencies = [
 
 [project.scripts]
 metax = "metax.gui.main_gui:runGUI"
+metax-report = "metax.report.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -57,7 +60,7 @@ include = ["metax", "metax.*"]
 version = {attr = "metax.utils.version.__version__"}
 
 [tool.setuptools.package-data]
-metax = ["data/example_data/*"]
+metax = ["data/example_data/*", "report/templates/*.j2"]
 
 [project.urls]
 Homepage = "https://github.com/byemaxx/MetaX"

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ scikit-bio>=0.6.3
 adjustText>=1.1.1
 openpyxl
 pyproject-toml>=0.0.10
+PyYAML>=6.0
+Jinja2>=3.1
 statsmodels
 seaborn>=0.13.2
 numba>=0.60.0

--- a/tests/test_auto_report_config.py
+++ b/tests/test_auto_report_config.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from metax.report.config import AutoReportConfig, load_config_from_yaml, save_config_to_yaml
+from metax.report.paths import ReportPaths
+from metax.report.registry import ResultRegistry
+
+
+def test_yaml_config_roundtrip(tmp_path: Path):
+    config = AutoReportConfig()
+    config.input.otf_path = "input.tsv"
+    config.input.meta_path = "meta.tsv"
+    config.analysis.group_meta = "Group"
+    config.report.output_dir = str(tmp_path / "report")
+
+    path = tmp_path / "config.yaml"
+    save_config_to_yaml(config, path)
+    loaded = load_config_from_yaml(path)
+
+    assert loaded.input.otf_path == "input.tsv"
+    assert loaded.input.meta_path == "meta.tsv"
+    assert loaded.analysis.group_meta == "Group"
+    assert loaded.report.output_dir == str(tmp_path / "report")
+
+
+def test_auto_report_defaults_match_gui_reuse_plan():
+    config = AutoReportConfig()
+
+    assert config.tables.taxa_levels == ["p", "g", "s"]
+    assert config.tables.function_columns == "auto"
+    assert config.plots.run_pca is True
+    assert config.plots.run_correlation is True
+    assert config.plots.run_box is True
+    assert config.plots.run_bar is True
+    assert config.plots.run_alpha_diversity is True
+    assert config.plots.run_beta_diversity is True
+    assert config.plots.run_treemap is True
+    assert config.plots.run_sunburst is True
+    assert config.plots.run_sankey is True
+    assert config.plots.run_pca_3d is False
+    assert config.plots.run_tsne is False
+    assert config.plots.run_upset is False
+    assert config.plots.run_network is False
+
+
+def test_report_paths_create_expected_directories(tmp_path: Path):
+    paths = ReportPaths(tmp_path / "report")
+    paths.create()
+
+    assert paths.output_dir.exists()
+    assert paths.taxa_tables_dir.exists()
+    assert paths.function_tables_dir.exists()
+    assert paths.otf_tables_dir.exists()
+    assert paths.qc_tables_dir.exists()
+    assert paths.overview_figures_dir.exists()
+    assert paths.logs_dir.exists()
+
+
+def test_result_registry_records_outputs(tmp_path: Path):
+    registry = ResultRegistry()
+    registry.add_table("table", tmp_path / "table.tsv", title="Table")
+    registry.add_figure("figure", tmp_path / "figure.png", figure_type="png")
+    registry.add_warning("warning", source="test")
+
+    data = registry.to_dict()
+    assert data["tables"][0]["key"] == "table"
+    assert data["figures"][0]["figure_type"] == "png"
+    assert data["warnings"][0]["message"] == "warning"

--- a/tests/test_auto_report_workflow.py
+++ b/tests/test_auto_report_workflow.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+
+import pandas as pd
+
+from metax.report import AutoOTFReport, AutoReportConfig
+
+
+def test_auto_report_runs_on_example_dataset(tmp_path: Path):
+    repo_root = Path(__file__).resolve().parents[1]
+    config = AutoReportConfig()
+    config.input.otf_path = str(repo_root / "metax" / "data" / "example_data" / "Example_OTF.tsv")
+    config.input.meta_path = str(repo_root / "metax" / "data" / "example_data" / "Example_Meta.tsv")
+    config.analysis.group_meta = "Sugar_type"
+    config.analysis.control_group = "PBS"
+    config.report.output_dir = str(tmp_path / "example_report")
+    config.report.overwrite = True
+    config.plots.run_correlation = False
+    config.plots.run_heatmap = False
+    config.plots.run_box = False
+    config.plots.run_bar = False
+    config.plots.run_diversity = False
+    config.plots.run_alpha_diversity = False
+    config.plots.run_beta_diversity = False
+    config.plots.run_treemap = False
+    config.plots.run_sunburst = False
+    config.plots.run_sankey = False
+
+    result = AutoOTFReport(config).run()
+
+    assert result.index_html_path.exists()
+    assert result.summary_json_path.exists()
+    assert (result.output_dir / "config_used.yaml").exists()
+    for level in ["p", "g", "s"]:
+        assert (result.output_dir / "tables" / "taxa" / f"taxa_table_{level}.tsv").exists()
+    for function_name in ["KEGG_ko_name", "Gene"]:
+        assert (result.output_dir / "tables" / "function" / f"function_table_{function_name}.tsv").exists()
+        for level in ["p", "g", "s"]:
+            assert (result.output_dir / "tables" / "otf" / f"otf_table_{level}_{function_name}.tsv").exists()
+    otf_table = result.output_dir / "tables" / "otf" / "otf_table_s_KEGG_ko_name.tsv"
+    assert not pd.read_csv(otf_table, sep="\t").empty
+    taxa_anova = result.output_dir / "stats" / "taxa" / "taxa_s_anova.tsv"
+    taxa_cho_vs_pbs = result.output_dir / "stats" / "taxa" / "taxa_s_CHO_vs_PBS.tsv"
+    taxa_dunnett = result.output_dir / "stats" / "taxa" / "taxa_s_dunnett.tsv"
+    pca = result.output_dir / "figures" / "basic" / "pca_taxa_s.png"
+    pca_js = result.output_dir / "figures" / "basic" / "pca_taxa_s.html"
+    volcano = result.output_dir / "figures" / "differential" / "volcano_taxa_s_CHO_vs_PBS.png"
+    volcano_js = result.output_dir / "figures" / "differential" / "volcano_taxa_s_CHO_vs_PBS.html"
+    assert taxa_anova.exists()
+    assert taxa_dunnett.exists()
+    assert taxa_cho_vs_pbs.exists()
+    assert pca.exists()
+    assert pca_js.exists()
+    assert volcano.exists()
+    assert volcano_js.exists()
+    stats_df = pd.read_csv(taxa_cho_vs_pbs, sep="\t")
+    assert {"feature_id", "log2FC", "p_value", "q_value", "significant", "direction"}.issubset(stats_df.columns)
+    assert not stats_df.empty
+    assert len(result.registry.stats) >= 3
+    assert len(result.registry.figures) >= 1
+
+
+def test_plot_builder_uses_gui_plotters_only():
+    source = (Path(__file__).resolve().parents[1] / "metax" / "report" / "plot_builder.py").read_text()
+
+    forbidden_tokens = [
+        "from sklearn",
+        "import seaborn",
+        "import numpy",
+        "sns.scatterplot",
+        "sns.heatmap",
+        "sns.clustermap",
+        "sns.boxplot",
+        "sns.barplot",
+        "PCA(",
+        "StandardScaler",
+    ]
+    for token in forbidden_tokens:
+        assert token not in source


### PR DESCRIPTION
This pull request introduces a new modular architecture for the `metax.report` package, adding robust configuration, CLI, registry, and path management systems, as well as new HTML templates for figure and plot rendering. The main themes are improved configurability, extensibility, and user interface enhancements for report generation.

**Core Infrastructure and Configuration:**

* Added a comprehensive configuration system using dataclasses in `config.py`, supporting YAML import/export and detailed report, analysis, table, statistics, and plot options. This enables flexible and reproducible report setups.
* Established a new CLI entrypoint in `cli.py` for generating reports, with argument parsing, config file support, and error handling, allowing command-line automation and integration.
* Updated the `__init__.py` to set up a dedicated Matplotlib config directory and expose all major config and workflow classes at the package level, improving import ergonomics and reproducibility.

**Report Output Management:**

* Introduced `ReportPaths` in `paths.py` to standardize and create all necessary output directories for tables, stats, figures, and logs, ensuring consistent file organization.
* Added a `ResultRegistry` in `registry.py` to track generated tables, figures, stats, HTML, warnings, errors, and runtime metadata, with JSON serialization for downstream consumption or debugging.

**User Interface and Templates:**

* Added new Jinja2 HTML templates for rendering figure tiles (`figure_tile.html.j2`) and a basic plots section (`section_basic_plots.html.j2`), providing a user-friendly, searchable, and interactive report interface for exploring generated outputs. [[1]](diffhunk://#diff-673488b7fa01f467f1964b6491aadac00d977b588a324ded8f13977944a679fdR1-R46) [[2]](diffhunk://#diff-85bdd1a2946181973a87f41b88af264a47929393c700c0ce021e773d2626f0a1R1-R99)