### PR TITLE
Add interactive selection for function columns in report CLI

### DIFF
--- a/metax/report/cli.py
+++ b/metax/report/cli.py
@@ -10,6 +10,9 @@ from .table_builder import DEFAULT_EXCLUDED_FUNCTION_COLUMNS
 from .workflow import AutoOTFReport
 
 
+NON_FUNCTION_COLUMNS = {"Taxon"}
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Generate a MetaX Auto OTF HTML report.")
     parser.add_argument("--otf", help="Path to the OTF table.")
@@ -165,7 +168,7 @@ def _detect_available_function_columns(otf_path: str | Path) -> list[str]:
     seen: set[str] = set()
     ordered: list[str] = []
     for name in available:
-        if name == "Taxon" or name in seen:
+        if name in NON_FUNCTION_COLUMNS or name in seen:
             continue
         ordered.append(name)
         seen.add(name)
@@ -173,14 +176,9 @@ def _detect_available_function_columns(otf_path: str | Path) -> list[str]:
 
 
 def _read_tsv_header(path: Path) -> list[str]:
-    try:
-        with path.open("r", encoding="utf-8", newline="") as handle:
-            reader = csv.reader(handle, delimiter="\t")
-            return next(reader)
-    except UnicodeDecodeError:
-        with path.open("r", encoding="utf-8-sig", newline="") as handle:
-            reader = csv.reader(handle, delimiter="\t")
-            return next(reader)
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle, delimiter="\t")
+        return next(reader)
 
 
 def _prompt_function_columns(otf_path: str | Path) -> list[str]:

--- a/metax/report/cli.py
+++ b/metax/report/cli.py
@@ -4,7 +4,10 @@ import argparse
 import sys
 from pathlib import Path
 
+import csv
+
 from .config import AutoReportConfig, load_config_from_yaml
+from .table_builder import DEFAULT_EXCLUDED_FUNCTION_COLUMNS
 from .workflow import AutoOTFReport
 
 
@@ -16,7 +19,23 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--group", help="Metadata column used for grouping.")
     parser.add_argument("--control", help="Control group inside the grouping column.")
     parser.add_argument("--taxa-levels", help="Comma-separated taxa levels, e.g. p,g,s or all.")
-    parser.add_argument("--func", help="Comma-separated function annotation columns, or auto.")
+    parser.add_argument(
+        "--func",
+        help=(
+            "Comma-separated function annotation columns; or one of: auto, all, prompt. "
+            "Use prompt to list available function columns in the OTF file and interactively choose."
+        ),
+    )
+    parser.add_argument(
+        "--list-func",
+        action="store_true",
+        help="List available function annotation columns in the OTF file and exit.",
+    )
+    parser.add_argument(
+        "--select-func",
+        action="store_true",
+        help="Interactively select function annotation columns from the OTF file (same as --func prompt).",
+    )
     parser.add_argument("--config", help="YAML configuration file.")
     parser.add_argument("--sample-col-prefix", help="Sample intensity column prefix.")
     parser.add_argument("--peptide-col-name", help="Peptide column name.")
@@ -48,8 +67,17 @@ def config_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) 
         config.analysis.control_group = args.control
     if args.taxa_levels is not None:
         config.tables.taxa_levels = _split_csv(args.taxa_levels)
-    if args.func is not None:
-        config.tables.function_columns = "auto" if args.func == "auto" else _split_csv(args.func)
+    if args.func is not None or args.select_func:
+        func_value = "prompt" if args.select_func else str(args.func)
+        func_value_lower = func_value.strip().lower()
+        if func_value_lower == "auto":
+            config.tables.function_columns = "auto"
+        elif func_value_lower == "all":
+            config.tables.function_columns = _detect_available_function_columns(config.input.otf_path)
+        elif func_value_lower in {"prompt", "select"}:
+            config.tables.function_columns = _prompt_function_columns(config.input.otf_path)
+        else:
+            config.tables.function_columns = _split_csv(func_value)
     if args.sample_col_prefix is not None:
         config.input.sample_col_prefix = args.sample_col_prefix
     if args.peptide_col_name is not None:
@@ -84,6 +112,25 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     try:
+        if args.list_func:
+            if args.otf:
+                otf_path = args.otf
+            elif args.config:
+                config = load_config_from_yaml(args.config)
+                if not config.input.otf_path:
+                    parser.error("Config does not define input.otf_path and --otf was not provided.")
+                otf_path = config.input.otf_path
+            else:
+                parser.error("--otf is required for --list-func unless --config is provided.")
+
+            available = _detect_available_function_columns(otf_path)
+            if not available:
+                print("No function annotation columns detected (requires both <name> and <name>_prop columns).")
+                return 0
+            print("Available function annotation columns:")
+            for item in available:
+                print(f"- {item}")
+            return 0
         config = config_from_args(args, parser)
         result = AutoOTFReport(config).run()
         print(Path(result.index_html_path))
@@ -97,6 +144,90 @@ def _split_csv(value: str) -> list[str]:
     if value.lower() == "all":
         return ["all"]
     return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def _detect_available_function_columns(otf_path: str | Path) -> list[str]:
+    path = Path(otf_path)
+    if not path.exists():
+        raise FileNotFoundError(f"OTF file does not exist: {path}")
+    header = _read_tsv_header(path)
+    column_set = set(header)
+    detected: set[str] = set()
+    for col in header:
+        if not str(col).endswith("_prop"):
+            continue
+        base = str(col)[: -len("_prop")]
+        if base and base in column_set:
+            detected.add(base)
+
+    # Keep stable order for usability.
+    available = [name for name in header if name in detected]
+    # De-dup while preserving order.
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for name in available:
+        if name not in seen:
+            ordered.append(name)
+            seen.add(name)
+    return ordered
+
+
+def _read_tsv_header(path: Path) -> list[str]:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            reader = csv.reader(handle, delimiter="\t")
+            return next(reader)
+    except UnicodeDecodeError:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.reader(handle, delimiter="\t")
+            return next(reader)
+
+
+def _prompt_function_columns(otf_path: str | Path) -> list[str]:
+    available = _detect_available_function_columns(otf_path)
+    if not available:
+        raise ValueError(
+            "No function annotation columns detected in OTF (requires both <name> and <name>_prop columns)."
+        )
+
+    print("Detected function annotation columns in OTF:")
+    for idx, name in enumerate(available, start=1):
+        excluded = " (excluded by default)" if name in DEFAULT_EXCLUDED_FUNCTION_COLUMNS else ""
+        print(f"  {idx:>3}. {name}{excluded}")
+
+    prompt = (
+        "Select functions by number or name (comma-separated). "
+        "Examples: 1,2,5  |  KEGG_ko_name,Gene  |  all\n"
+        "> "
+    )
+    raw = input(prompt).strip()
+    if not raw:
+        raise ValueError("No function selection provided.")
+    if raw.lower() == "all":
+        return list(available)
+
+    tokens = [item.strip() for item in raw.split(",") if item.strip()]
+    selected: list[str] = []
+    for token in tokens:
+        if token.isdigit():
+            idx = int(token)
+            if idx < 1 or idx > len(available):
+                raise ValueError(f"Invalid function index: {idx}. Valid range: 1..{len(available)}")
+            name = available[idx - 1]
+        else:
+            # Case-insensitive match; must be unique.
+            matches = [item for item in available if item.lower() == token.lower()]
+            if not matches:
+                raise ValueError(f"Unknown function column: {token}. Use --list-func to see options.")
+            if len(matches) > 1:
+                raise ValueError(f"Ambiguous function column name: {token}")
+            name = matches[0]
+        if name not in selected:
+            selected.append(name)
+
+    if not selected:
+        raise ValueError("No functions selected.")
+    return selected
 
 
 if __name__ == "__main__":

--- a/metax/report/cli.py
+++ b/metax/report/cli.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import sys
 from pathlib import Path
-
-import csv
 
 from .config import AutoReportConfig, load_config_from_yaml
 from .table_builder import DEFAULT_EXCLUDED_FUNCTION_COLUMNS
@@ -166,9 +165,10 @@ def _detect_available_function_columns(otf_path: str | Path) -> list[str]:
     seen: set[str] = set()
     ordered: list[str] = []
     for name in available:
-        if name not in seen:
-            ordered.append(name)
-            seen.add(name)
+        if name == "Taxon" or name in seen:
+            continue
+        ordered.append(name)
+        seen.add(name)
     return ordered
 
 

--- a/tests/test_auto_report_config.py
+++ b/tests/test_auto_report_config.py
@@ -3,6 +3,12 @@ from pathlib import Path
 from metax.report.config import AutoReportConfig, load_config_from_yaml, save_config_to_yaml
 from metax.report.paths import ReportPaths
 from metax.report.registry import ResultRegistry
+from metax.report.reproducibility import (
+    CONFIG_FILE_NAME,
+    PYTHON_SCRIPT_NAME,
+    WINDOWS_SCRIPT_NAME,
+    save_reproducibility_artifacts,
+)
 
 
 def test_yaml_config_roundtrip(tmp_path: Path):
@@ -65,6 +71,30 @@ def test_result_registry_records_outputs(tmp_path: Path):
     assert data["tables"][0]["key"] == "table"
     assert data["figures"][0]["figure_type"] == "png"
     assert data["warnings"][0]["message"] == "warning"
+
+
+def test_reproducibility_artifacts_export_rerunnable_scripts(tmp_path: Path):
+    config = AutoReportConfig()
+    artifacts = save_reproducibility_artifacts(config, tmp_path)
+
+    python_script = tmp_path / PYTHON_SCRIPT_NAME
+    windows_script = tmp_path / WINDOWS_SCRIPT_NAME
+
+    assert artifacts["python_script"] == python_script
+    assert artifacts["windows_script"] == windows_script
+    assert artifacts["config"] == tmp_path / CONFIG_FILE_NAME
+    assert artifacts["config"].exists()
+    assert python_script.exists()
+    assert windows_script.exists()
+
+    python_text = python_script.read_text(encoding="utf-8")
+    assert f'with_name("{CONFIG_FILE_NAME}")' in python_text
+    assert "load_config_from_yaml(config_path)" in python_text
+    assert "AutoOTFReport(config).run()" in python_text
+
+    windows_text = windows_script.read_text(encoding="utf-8")
+    assert "METAX_PYTHON" in windows_text
+    assert PYTHON_SCRIPT_NAME in windows_text
 
 
 def test_cli_function_detection_excludes_taxon(tmp_path: Path):

--- a/tests/test_auto_report_config.py
+++ b/tests/test_auto_report_config.py
@@ -123,6 +123,19 @@ def test_cli_function_detection_handles_utf8_bom(tmp_path: Path):
     assert _detect_available_function_columns(otf_path) == ["Gene"]
 
 
+def test_cli_function_detection_requires_matching_prop_pair(tmp_path: Path):
+    from metax.report.cli import _detect_available_function_columns
+
+    otf_path = tmp_path / "otf.tsv"
+    otf_path.write_text(
+        "Sequence\tGene\tKEGG_ko_name_prop\tTaxon\tTaxon_prop\n"
+        "pep1\tgeneA\tkoA\td__Bacteria\t1\n",
+        encoding="utf-8",
+    )
+
+    assert _detect_available_function_columns(otf_path) == []
+
+
 def test_cli_func_all_excludes_taxon_from_config(tmp_path: Path):
     from metax.report.cli import build_parser, config_from_args
 

--- a/tests/test_auto_report_config.py
+++ b/tests/test_auto_report_config.py
@@ -65,3 +65,33 @@ def test_result_registry_records_outputs(tmp_path: Path):
     assert data["tables"][0]["key"] == "table"
     assert data["figures"][0]["figure_type"] == "png"
     assert data["warnings"][0]["message"] == "warning"
+
+
+def test_cli_function_detection_excludes_taxon(tmp_path: Path):
+    from metax.report.cli import _detect_available_function_columns
+
+    otf_path = tmp_path / "otf.tsv"
+    otf_path.write_text(
+        "Sequence\tTaxon\tTaxon_prop\tGene\tGene_prop\tKEGG_ko_name\tKEGG_ko_name_prop\n"
+        "pep1\td__Bacteria\t1\tgeneA\t1\tkoA\t1\n",
+        encoding="utf-8",
+    )
+
+    assert _detect_available_function_columns(otf_path) == ["Gene", "KEGG_ko_name"]
+
+
+def test_cli_func_all_excludes_taxon_from_config(tmp_path: Path):
+    from metax.report.cli import build_parser, config_from_args
+
+    otf_path = tmp_path / "otf.tsv"
+    otf_path.write_text(
+        "Sequence\tTaxon\tTaxon_prop\tGene\tGene_prop\n"
+        "pep1\td__Bacteria\t1\tgeneA\t1\n",
+        encoding="utf-8",
+    )
+
+    parser = build_parser()
+    args = parser.parse_args(["--otf", str(otf_path), "--out", str(tmp_path / "report"), "--func", "all"])
+    config = config_from_args(args, parser)
+
+    assert config.tables.function_columns == ["Gene"]

--- a/tests/test_auto_report_config.py
+++ b/tests/test_auto_report_config.py
@@ -80,6 +80,19 @@ def test_cli_function_detection_excludes_taxon(tmp_path: Path):
     assert _detect_available_function_columns(otf_path) == ["Gene", "KEGG_ko_name"]
 
 
+def test_cli_function_detection_handles_utf8_bom(tmp_path: Path):
+    from metax.report.cli import _detect_available_function_columns
+
+    otf_path = tmp_path / "bom_otf.tsv"
+    otf_path.write_text(
+        "Gene\tGene_prop\tTaxon\tTaxon_prop\n"
+        "geneA\t1\td__Bacteria\t1\n",
+        encoding="utf-8-sig",
+    )
+
+    assert _detect_available_function_columns(otf_path) == ["Gene"]
+
+
 def test_cli_func_all_excludes_taxon_from_config(tmp_path: Path):
     from metax.report.cli import build_parser, config_from_args
 


### PR DESCRIPTION
This PR rebases the report CLI function-column selection work onto the current `dev` branch.

Changes:
- Add `--list-func` to list detected function annotation columns from an OTF table.
- Add `--select-func` / `--func prompt` for interactive function-column selection.
- Support `--func all` by detecting valid `<function>` / `<function>_prop` column pairs.
- Exclude non-function structural columns such as `Taxon` from detected function columns.
- Read TSV headers with `utf-8-sig` to handle UTF-8 BOM safely.
- Preserve the existing reproducibility artifact tests from `dev` and add CLI regression tests.