### PR TITLE
Enhance MGnify downloads and update dbCAN URL handling

### DIFF
--- a/Docs/ChangeLog.md
+++ b/Docs/ChangeLog.md
@@ -1,3 +1,11 @@
+# Version: 2.4.2
+## Date: 2026-07-09
+### Changes:
+- New: Added MGnify database update sources.
+- Optimize: Improved update cancellation and shutdown handling for database downloads and annotation builds.
+- Fix: Updated the dbCAN download source and made its identifier merging more reliable.
+
+
 # Version: 2.4.1
 ## Date: 2026-07-08
 ### Changes:

--- a/Docs/MetaX_Cookbook.md
+++ b/Docs/MetaX_Cookbook.md
@@ -711,6 +711,8 @@ You can select <u>**meta**</u> <u>**groups**</u> or <u>**samples**</u> (default:
 
   Ensure you download the correct database type corresponding to your data.
 
+  MetaX supports the MGnify catalogues listed in the Database Builder selector, including barley-rhizosphere, human-skin, maize-rhizosphere, marine-sediment, soil, and tomato-rhizosphere. The selector and command-line options are generated from MetaX's supported-source list. `marine-eukaryotes` is intentionally not enabled by default because it is a beta eukaryotic catalogue with an eggNOG annotation caveat.
+
   ![dbbuilder](./MetaX_Cookbook.assets/dbbuilder.png)
 
   **Option 2: Build Database Using Own Data**

--- a/Docs/MetaX_Cookbook.md
+++ b/Docs/MetaX_Cookbook.md
@@ -762,7 +762,7 @@ The **Database Updater** allows updating the database built by the **Database Bu
 
   **Option 1: Built-in Mode**
 
-  We recommend some extended databases, such as [dbCAN_seq](https://bcb.unl.edu/dbCAN_seq).
+  Built-in dbCAN_seq mode merges precomputed annotations by exact protein ID; it does not run sequence-similarity searches or re-annotate custom proteins. Incoming annotation columns replace existing columns with the same names, and MetaX writes a warning listing the replaced columns. For a custom protein database, run dbCAN/run_dbCAN on your own protein FASTA and import the resulting TSV with matching MetaX protein IDs using **Option 2**. Built-in sources are available from [dbCAN_seq](https://pro.unl.edu/dbCAN_seq/).
 
   **Option 2: TSV Table**
 

--- a/Docs/index.html
+++ b/Docs/index.html
@@ -1903,7 +1903,7 @@ d__Bacteria;p__Firmicutes_A;c__Clostridia;o__Oscillospirales;f__Ruminococcaceae;
 </ul>
 <span class="image-wrap"><img alt="db_updater" src="./MetaX_Cookbook.assets/db_updater.png" decoding="async" class="doc-image"></span>
 <p><strong>Option 1: Built-in Mode</strong></p>
-<p>We recommend some extended databases, such as <a href="https://bcb.unl.edu/dbCAN_seq">dbCAN_seq</a>.</p>
+<p>Built-in dbCAN_seq mode merges precomputed annotations by exact protein ID; it does not run sequence-similarity searches or re-annotate custom proteins. Incoming annotation columns replace existing columns with the same names, and MetaX writes a warning listing the replaced columns. For a custom protein database, run dbCAN/run_dbCAN on your own protein FASTA and import the resulting TSV with matching MetaX protein IDs using <strong>Option 2</strong>. Built-in sources are available from <a href="https://pro.unl.edu/dbCAN_seq/">dbCAN_seq</a>.</p>
 <p><strong>Option 2: TSV Table</strong></p>
 <p>Extend the database by adding a new database to the database table. Ensure the column separator is a tab and the first column is the Protein name, with other columns containing function annotations.</p>
 <p><strong>Example:</strong></p>

--- a/metax/database_builder/database_builder_mag.py
+++ b/metax/database_builder/database_builder_mag.py
@@ -13,6 +13,7 @@ import pandas as pd
 import sqlite3
 import os
 import urllib.request
+import tempfile
 from tqdm import tqdm
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
@@ -35,26 +36,43 @@ def _raise_if_cancelled(cancel_event):
 def download_with_retry(url, save_path, max_retries=3, retry_delay=5, cancel_event=None):
     """Download function with retry mechanism"""
     file_name = url.split('/')[-1]
+    destination = os.path.join(save_path, file_name)
     for attempt in range(max_retries):
         _raise_if_cancelled(cancel_event)
+        temp_path = None
         try:
-            with urllib.request.urlopen(url, timeout=30) as response, open(os.path.join(save_path, file_name), 'wb') as out_file:
-                data = response.read()
-                _raise_if_cancelled(cancel_event)
-                out_file.write(data)
+            with urllib.request.urlopen(url, timeout=30) as response:
+                with tempfile.NamedTemporaryFile(
+                    mode='wb', prefix=f'.{file_name}.', suffix='.part', dir=save_path, delete=False
+                ) as out_file:
+                    temp_path = out_file.name
+                    while True:
+                        _raise_if_cancelled(cancel_event)
+                        data = response.read(1024 * 1024)
+                        if not data:
+                            break
+                        _raise_if_cancelled(cancel_event)
+                        out_file.write(data)
+            _raise_if_cancelled(cancel_event)
+            os.replace(temp_path, destination)
+            temp_path = None
             return file_name
         except DownloadCancelled:
             raise
         except (URLError, HTTPError) as e:
             if attempt < max_retries - 1:
                 print(f"\nDownload failed for {file_name}, retrying in {retry_delay} seconds... (Error: {str(e)})")
-                time.sleep(retry_delay)
+                if cancel_event is not None and cancel_event.wait(retry_delay):
+                    raise DownloadCancelled("MGnify database download cancelled by user.")
             else:
                 print(f"\nDownload failed for {file_name}, maximum retries reached.")
                 return None
         except Exception as e:
             print(f"\nUnknown error occurred while downloading {file_name}: {str(e)}")
             return None
+        finally:
+            if temp_path is not None and os.path.exists(temp_path):
+                os.remove(temp_path)
 
 def download_mgyg2taxa(save_path, db_type = "human-gut", cancel_event=None):
     """Download metadata file for the specified database type"""
@@ -93,14 +111,15 @@ def download_mgyg2taxa(save_path, db_type = "human-gut", cancel_event=None):
             raise
     return path
 
-def build_id2taxa_db(save_path, db_name, file_name = 'genomes-all_metadata.tsv', meta_path = None):
+def build_id2taxa_db(save_path, db_name, file_name='genomes-all_metadata.tsv', meta_path=None, cancel_event=None):
     """Build id2taxa database and return a list of MGYG IDs"""
     try:
+        _raise_if_cancelled(cancel_event)
         if meta_path is None:
             df = pd.read_csv(os.path.join(save_path, file_name), sep='\t', header=0)
         else:
             df = pd.read_csv(meta_path, sep='\t', header=0)
-            
+        _raise_if_cancelled(cancel_event)
         if not os.path.exists(save_path):
             os.makedirs(save_path)
         
@@ -121,6 +140,7 @@ def build_id2taxa_db(save_path, db_name, file_name = 'genomes-all_metadata.tsv',
         if len(result) > 0:
             print(f"{table_name} already exists in db, skipping.")
         else:
+            _raise_if_cancelled(cancel_event)
             df.to_sql("id2taxa", conn, index=True, if_exists='replace')
             print("id2taxa database built successfully.")
             
@@ -188,12 +208,14 @@ def download_id2annotation(down_list, save_path, cancel_event=None):
         _raise_if_cancelled(cancel_event)
     print("Annotation files download completed.")
 
-def read_file(args):
+def read_file(args, cancel_event=None):
     """Read and process a single annotation file"""
     file_path = args[0]
     try:
+        _raise_if_cancelled(cancel_event)
         # Files should already be validated, so we can read directly
         df = pd.read_csv(file_path, sep='\t', header=0, index_col=None)
+        _raise_if_cancelled(cancel_event)
         
         # Check if the dataframe is empty
         if df.empty:
@@ -207,12 +229,13 @@ def read_file(args):
         # Since files are pre-validated, any error here is unexpected
         raise
 
-def validate_annotation_files(file_list, path):
+def validate_annotation_files(file_list, path, cancel_event=None):
     """Validate annotation files and return list of valid files"""
     valid_files = []
     invalid_files = []
     
     for f in file_list:
+        _raise_if_cancelled(cancel_event)
         file_path = os.path.join(path, f)
         try:
             if not os.path.exists(file_path):
@@ -255,9 +278,10 @@ def validate_annotation_files(file_list, path):
     print(f"All files are valid: {len(valid_files)}/{len(file_list)}")
     return valid_files
 
-def build_id2annotation_db(save_path, db_name, dir_name = 'id2annotation', mgyg_dir = None):
+def build_id2annotation_db(save_path, db_name, dir_name='id2annotation', mgyg_dir=None, cancel_event=None):
     """Build id2annotation database from downloaded files"""
     try:
+        _raise_if_cancelled(cancel_event)
         if mgyg_dir is None:
             file_list = os.listdir(os.path.join(save_path, dir_name))
             path = os.path.join(save_path, dir_name)
@@ -266,16 +290,20 @@ def build_id2annotation_db(save_path, db_name, dir_name = 'id2annotation', mgyg_
             path = mgyg_dir
 
         print("Validating annotation files...")
-        valid_files = validate_annotation_files(file_list, path)
+        valid_files = validate_annotation_files(file_list, path, cancel_event=cancel_event)
         
         # If we reach here, all files are valid
         print("Loading annotation files...")
         with ThreadPoolExecutor() as executor:
             df_list = []
-            futures = [executor.submit(read_file, (os.path.join(path, f),)) for f in valid_files]
+            futures = [
+                executor.submit(read_file, (os.path.join(path, f),), cancel_event)
+                for f in valid_files
+            ]
             with tqdm(total=len(valid_files), desc="Processing files") as pbar:
                 for future in as_completed(futures):
                     result = future.result()
+                    _raise_if_cancelled(cancel_event)
                     pbar.update(1)
                     if result is not None:  # Only add non-None results
                         df_list.append(result)
@@ -287,6 +315,7 @@ def build_id2annotation_db(save_path, db_name, dir_name = 'id2annotation', mgyg_
         
         print("Concatenating annotation files...")
         df = pd.concat(df_list, ignore_index=True)
+        _raise_if_cancelled(cancel_event)
         df = df.drop_duplicates()
         df = df.rename(columns=lambda x: x.replace('#', ''))
         df.rename(columns={df.columns[0]: "ID"}, inplace=True)
@@ -313,7 +342,12 @@ def build_id2annotation_db(save_path, db_name, dir_name = 'id2annotation', mgyg_
             print(f"{table_name} already exists in db, skipping.")
         else:
             print("Building id2annotation database...")
+            _raise_if_cancelled(cancel_event)
             df.to_sql("id2annotation", conn, index=True, if_exists='replace')
+            if cancel_event is not None and cancel_event.is_set():
+                c.execute("DROP TABLE IF EXISTS id2annotation")
+                conn.commit()
+                _raise_if_cancelled(cancel_event)
             print("id2annotation database built successfully.")
             
     except Exception as e:
@@ -377,13 +411,18 @@ def download_and_build_database(save_path, db_name, db_type, meta_path=None, mgy
             if meta_path is None:
                 download_mgyg2taxa(save_path, db_type, cancel_event=cancel_event)
             _raise_if_cancelled(cancel_event)
-            mgyg_list = build_id2taxa_db(save_path, db_name, meta_path=meta_path)
+            mgyg_list = build_id2taxa_db(
+                save_path, db_name, meta_path=meta_path, cancel_event=cancel_event
+            )
             _raise_if_cancelled(cancel_event)
             down_list = create_download_list(mgyg_list, db_type)
             if mgyg_dir is None:
                 download_id2annotation(down_list, save_path, cancel_event=cancel_event)
             _raise_if_cancelled(cancel_event)
-            build_id2annotation_db(save_path, db_name, mgyg_dir=mgyg_dir)
+            build_id2annotation_db(
+                save_path, db_name, mgyg_dir=mgyg_dir, cancel_event=cancel_event
+            )
+            _raise_if_cancelled(cancel_event)
 
         elif status == "no id2annotation":
             print("Database already exists, skipping id2taxa build.")
@@ -391,7 +430,10 @@ def download_and_build_database(save_path, db_name, db_type, meta_path=None, mgy
             if mgyg_dir is None:
                 download_id2annotation(down_list, save_path, cancel_event=cancel_event)
             _raise_if_cancelled(cancel_event)
-            build_id2annotation_db(save_path, db_name, mgyg_dir=mgyg_dir)
+            build_id2annotation_db(
+                save_path, db_name, mgyg_dir=mgyg_dir, cancel_event=cancel_event
+            )
+            _raise_if_cancelled(cancel_event)
 
         else:
             print("Database already exists and complete, skipping build.")

--- a/metax/database_builder/database_builder_mag.py
+++ b/metax/database_builder/database_builder_mag.py
@@ -23,15 +23,28 @@ try:
 except ImportError:  # Support direct execution of this module as a script.
     from mgnify_sources import DB_URLS
 
-def download_with_retry(url, save_path, max_retries=3, retry_delay=5):
+
+class DownloadCancelled(Exception):
+    """Raised when the user cancels an MGnify database download."""
+
+
+def _raise_if_cancelled(cancel_event):
+    if cancel_event is not None and cancel_event.is_set():
+        raise DownloadCancelled("MGnify database download cancelled by user.")
+
+def download_with_retry(url, save_path, max_retries=3, retry_delay=5, cancel_event=None):
     """Download function with retry mechanism"""
     file_name = url.split('/')[-1]
     for attempt in range(max_retries):
+        _raise_if_cancelled(cancel_event)
         try:
             with urllib.request.urlopen(url, timeout=30) as response, open(os.path.join(save_path, file_name), 'wb') as out_file:
                 data = response.read()
+                _raise_if_cancelled(cancel_event)
                 out_file.write(data)
             return file_name
+        except DownloadCancelled:
+            raise
         except (URLError, HTTPError) as e:
             if attempt < max_retries - 1:
                 print(f"\nDownload failed for {file_name}, retrying in {retry_delay} seconds... (Error: {str(e)})")
@@ -43,7 +56,7 @@ def download_with_retry(url, save_path, max_retries=3, retry_delay=5):
             print(f"\nUnknown error occurred while downloading {file_name}: {str(e)}")
             return None
 
-def download_mgyg2taxa(save_path, db_type = "human-gut"):
+def download_mgyg2taxa(save_path, db_type = "human-gut", cancel_event=None):
     """Download metadata file for the specified database type"""
     if not os.path.exists(save_path):
         os.makedirs(save_path)
@@ -63,8 +76,16 @@ def download_mgyg2taxa(save_path, db_type = "human-gut"):
     print(f"Downloading genomes-all_metadata.tsv from {url}...")
     with tqdm(unit='B', unit_scale=True, miniters=1, desc=file_name) as t:
         try:
-            urllib.request.urlretrieve(url, path, reporthook=lambda x, y, z: t.update(y))
+            def reporthook(_, block_size, __):
+                _raise_if_cancelled(cancel_event)
+                t.update(block_size)
+
+            urllib.request.urlretrieve(url, path, reporthook=reporthook)
             print(f"{file_name} download completed.")
+        except DownloadCancelled:
+            if os.path.exists(path):
+                os.remove(path)
+            raise
         except Exception as e:
             print(f"\nDownload failed for {file_name}: {str(e)}")
             if os.path.exists(path):
@@ -128,13 +149,14 @@ def create_download_list(mgyg_list, db_type = "human-gut"):
             continue
     return url_list
 
-def download_id2annotation(down_list, save_path):
+def download_id2annotation(down_list, save_path, cancel_event=None):
     """Download eggNOG annotation files"""
     dir_name = 'id2annotation'
     os.makedirs(os.path.join(save_path, dir_name), exist_ok=True)
     
     need_download_list = []
     for url in down_list:
+        _raise_if_cancelled(cancel_event)
         file_name = url.split('/')[-1]
         if not os.path.exists(os.path.join(save_path, dir_name, file_name)):
             need_download_list.append(url)
@@ -147,13 +169,23 @@ def download_id2annotation(down_list, save_path):
             
     print(f"\nStarting download of {len(need_download_list)} files...")
     with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(download_with_retry, url, os.path.join(save_path, dir_name)) for url in need_download_list]
+        futures = [
+            executor.submit(download_with_retry, url, os.path.join(save_path, dir_name), cancel_event=cancel_event)
+            for url in need_download_list
+        ]
+        cancelled = False
         with tqdm(total=len(need_download_list), desc="Downloading") as pbar:
             for future in as_completed(futures):
-                result = future.result()
+                try:
+                    result = future.result()
+                except DownloadCancelled:
+                    cancelled = True
+                    continue
                 if result:
                     pbar.update(1)
                     pbar.set_postfix_str(result)
+    if cancelled:
+        _raise_if_cancelled(cancel_event)
     print("Annotation files download completed.")
 
 def read_file(args):
@@ -334,31 +366,39 @@ def check_db(db_path):
         print(f"Error checking database: {str(e)}")
         raise
 
-def download_and_build_database(save_path, db_name, db_type, meta_path=None, mgyg_dir=None):
+def download_and_build_database(save_path, db_name, db_type, meta_path=None, mgyg_dir=None, cancel_event=None):
     """Main function to download and build the database"""
     try:
+        _raise_if_cancelled(cancel_event)
         db_path = os.path.join(save_path, db_name)
         status = check_db(db_path)
 
         if status in ["no db", "no id2taxa"]:
             if meta_path is None:
-                download_mgyg2taxa(save_path, db_type)
+                download_mgyg2taxa(save_path, db_type, cancel_event=cancel_event)
+            _raise_if_cancelled(cancel_event)
             mgyg_list = build_id2taxa_db(save_path, db_name, meta_path=meta_path)
+            _raise_if_cancelled(cancel_event)
             down_list = create_download_list(mgyg_list, db_type)
             if mgyg_dir is None:
-                download_id2annotation(down_list, save_path)
+                download_id2annotation(down_list, save_path, cancel_event=cancel_event)
+            _raise_if_cancelled(cancel_event)
             build_id2annotation_db(save_path, db_name, mgyg_dir=mgyg_dir)
 
         elif status == "no id2annotation":
             print("Database already exists, skipping id2taxa build.")
             down_list = create_download_list(query_download_list(db_path), db_type)
             if mgyg_dir is None:
-                download_id2annotation(down_list, save_path)
+                download_id2annotation(down_list, save_path, cancel_event=cancel_event)
+            _raise_if_cancelled(cancel_event)
             build_id2annotation_db(save_path, db_name, mgyg_dir=mgyg_dir)
 
         else:
             print("Database already exists and complete, skipping build.")
             
+    except DownloadCancelled:
+        print("MGnify database build cancelled.")
+        raise
     except Exception as e:
         print(f"Error in database build process: {str(e)}")
         raise

--- a/metax/database_builder/database_builder_mag.py
+++ b/metax/database_builder/database_builder_mag.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # This script is used to build the database for the MetaX tool 
-# Database source: Unified Human Gastrointestinal Genome (UHGG) v2.0.1
-# Database ftp: http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.1/
+# Database source: MGnify Genomes FTP. Supported catalog versions are defined in mgnify_sources.DB_URLS.
 # Required downloads: 
 #   1. MGYG to EggNOG mapping files in the data folder
 #   2. MGYG to Taxa mapping file 
@@ -19,69 +18,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 from urllib.error import URLError, HTTPError
 
-# Combined URL dictionary for all database types
-DB_URLS = {
-    "chicken-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/chicken-gut/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "cow-rumen": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/cow-rumen/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "honeybee-gut": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/honeybee-gut/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-oral": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-oral/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-vaginal": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-vaginal/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "marine": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine/v2.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "mouse-gut": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/mouse-gut/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "non-model-fish-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/non-model-fish-gut/v2.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "pig-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/pig-gut/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "sheep-rumen": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/sheep-rumen/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "zebrafish-fecal": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/zebrafish-fecal/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    }
-}
+try:
+    from .mgnify_sources import DB_URLS
+except ImportError:  # Support direct execution of this module as a script.
+    from mgnify_sources import DB_URLS
 
 def download_with_retry(url, save_path, max_retries=3, retry_delay=5):
     """Download function with retry mechanism"""
@@ -423,7 +363,7 @@ def download_and_build_database(save_path, db_name, db_type, meta_path=None, mgy
         print(f"Error in database build process: {str(e)}")
         raise
 
-def build_db(args):
+def build_db(args, parser=None):
     """Build database based on command line arguments"""
     try:
         if args.auto:
@@ -460,18 +400,15 @@ def build_db(args):
             download_and_build_database(save_path, db_name, args.db_type)
                 
         else:
-            parser.print_help()
+            if parser is not None:
+                parser.print_help()
             
     except Exception as e:
         print(f"Error in build process: {str(e)}")
         raise
 
-if __name__ == "__main__":
-    # download_and_build_database(
-    #     save_path = os.path.abspath('C:/Users/Qing/Desktop/test'),
-    #     db_name = 'MetaX.db',
-    #     db_type = 'sheep-rumen'
-    # )
+def build_parser():
+    """Create the command-line parser for the MGnify database builder."""
     parser = argparse.ArgumentParser(
         description='Download Annotation of MGnify and create database for MetaX tool.')
 
@@ -486,10 +423,16 @@ if __name__ == "__main__":
     parser.add_argument('--meta_path', metavar='PATH', type=str,
                         help='Path of the genomes-all_metadata.tsv if already downloaded')
     parser.add_argument('--mgyg_dir', metavar='PATH', type=str,
-                        help='Directory of eggNOG annotation of UHGG if already downloaded')
+                        help='Directory of eggNOG annotation if already downloaded')
     parser.add_argument('--db_type', metavar='TYPE', type=str, default="human-gut",
-                        help='Database type (human-gut, human-oral, chicken-gut, cow-rumen, marine, non-model-fish-gut, pig-gut, zebrafish-fecal)')
+                        choices=tuple(sorted(DB_URLS)),
+                        help=f"MGnify database type. Supported values: {', '.join(sorted(DB_URLS))}")
+    return parser
+
+
+if __name__ == "__main__":
+    parser = build_parser()
 
     args = parser.parse_args()
-    build_db(args)
+    build_db(args, parser)
 

--- a/metax/database_builder/download_mgyg_faa.py
+++ b/metax/database_builder/download_mgyg_faa.py
@@ -7,69 +7,10 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 from urllib.error import URLError, HTTPError
 
-# Combined URL dictionary for all database types
-DB_URLS = {
-    "chicken-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/chicken-gut/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "cow-rumen": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/cow-rumen/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "honeybee-gut": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/honeybee-gut/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-oral": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-oral/v1.0.1",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "human-vaginal": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-vaginal/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "marine": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine/v2.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "mouse-gut": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/mouse-gut/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "non-model-fish-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/non-model-fish-gut/v2.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "pig-gut": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/pig-gut/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "sheep-rumen": {
-        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/sheep-rumen/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    },
-    "zebrafish-fecal": {
-        "base_url": "http://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/zebrafish-fecal/v1.0",
-        "metadata": "genomes-all_metadata.tsv",
-        "catalogue": "species_catalogue"
-    }
-}
+try:
+    from .mgnify_sources import DB_URLS
+except ImportError:  # Support direct execution of this module as a script.
+    from mgnify_sources import DB_URLS
 
 def download_with_retry(url, save_path, max_retries=3, retry_delay=5):
     """Download function with retry mechanism"""

--- a/metax/database_builder/mgnify_sources.py
+++ b/metax/database_builder/mgnify_sources.py
@@ -1,0 +1,158 @@
+"""Supported MGnify Genomes catalogue sources."""
+
+from urllib.error import HTTPError, URLError
+import urllib.request
+
+
+# Database source: MGnify Genomes FTP; supported catalog versions are defined in DB_URLS.
+DB_URLS = {
+    "human-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "human-oral": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-oral/v1.0.1",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "human-skin": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-skin/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "human-vaginal": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-vaginal/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "barley-rhizosphere": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/barley-rhizosphere/v2.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "chicken-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/chicken-gut/v1.0.1",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "cow-rumen": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/cow-rumen/v1.0.1",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "honeybee-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/honeybee-gut/v1.0.1",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "marine": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine/v2.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "marine-sediment": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine-sediment/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "maize-rhizosphere": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/maize-rhizosphere/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "mouse-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/mouse-gut/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "non-model-fish-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/non-model-fish-gut/v2.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "pig-gut": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/pig-gut/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "sheep-rumen": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/sheep-rumen/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "soil": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/soil/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "tomato-rhizosphere": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/tomato-rhizosphere/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+    "zebrafish-fecal": {
+        "base_url": "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/zebrafish-fecal/v1.0",
+        "metadata": "genomes-all_metadata.tsv",
+        "catalogue": "species_catalogue",
+    },
+}
+
+GUI_CATALOGUE_PRIORITY = (
+    "human-gut",
+    "human-oral",
+    "human-skin",
+    "human-vaginal",
+)
+
+
+def mgnify_catalogue_display_names():
+    """Return stable GUI labels for the supported MGnify catalogues."""
+    ordered_db_types = list(GUI_CATALOGUE_PRIORITY) + sorted(
+        set(DB_URLS).difference(GUI_CATALOGUE_PRIORITY)
+    )
+    return [
+        f"{db_type} ({DB_URLS[db_type]['base_url'].rsplit('/', 1)[-1]})"
+        for db_type in ordered_db_types
+    ]
+
+
+def validate_mgnify_source(db_type, check_catalogue=False, timeout=10):
+    """Validate the configured MGnify source and return its source metadata.
+
+    The metadata URL is always checked. Set ``check_catalogue`` to also verify
+    that the configured species catalogue directory is reachable.
+    """
+    if db_type not in DB_URLS:
+        supported = ", ".join(DB_URLS)
+        raise ValueError(
+            f"Unsupported MGnify database type: {db_type}. Supported values: {supported}"
+        )
+
+    db_info = DB_URLS[db_type]
+    urls = {"metadata": f"{db_info['base_url']}/{db_info['metadata']}"}
+    if check_catalogue:
+        urls["species catalogue"] = f"{db_info['base_url']}/{db_info['catalogue']}/"
+
+    for label, url in urls.items():
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:
+                if getattr(response, "status", 200) >= 400:
+                    raise RuntimeError(f"MGnify {label} URL returned HTTP status {response.status}: {url}")
+                if label == "metadata":
+                    header = response.read(65536).decode("utf-8-sig").splitlines()[0].split("\t")
+        except (HTTPError, URLError, OSError) as error:
+            raise RuntimeError(
+                f"MGnify {label} URL is unavailable for database type '{db_type}': {url}. "
+                "Check the configured catalogue version and the MGnify FTP index."
+            ) from error
+
+        if label == "metadata":
+            missing_columns = {"Species_rep", "Lineage"}.difference(header)
+            if missing_columns:
+                raise ValueError(
+                    f"MGnify metadata for database type '{db_type}' is missing required columns "
+                    f"{', '.join(sorted(missing_columns))}: {url}"
+                )
+
+    return db_info

--- a/metax/database_updater/database_updater.py
+++ b/metax/database_updater/database_updater.py
@@ -1,185 +1,347 @@
-import pandas as pd
-import sqlite3
 import os
+import sqlite3
+import tarfile
+import tempfile
+from io import StringIO
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlparse
+
+import pandas as pd
+
+
+DBCAN_SEQ_URLS = {
+    "dbCAN (HUMAN GUT)": "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz",
+    "dbCAN (COW RUMEN)": "https://pro.unl.edu/dbCAN_seq/download_file.php?file=COW%20RUMEN/dbCAN_overview.tar.gz",
+    "dbCAN (MARINE)": "https://pro.unl.edu/dbCAN_seq/download_file.php?file=MARINE/dbCAN_overview.tar.gz",
+}
+DBCAN_EXPECTED_COLUMNS = [
+    "ID",
+    "dbcan_EC",
+    "dbcan_HMMER",
+    "dbcan_eCAMI",
+    "dbcan_DIAMOND",
+    "dbcan_NumOfTools",
+]
+LOW_MATCH_RATE = 0.05
 
 
 def get_time():
     import datetime
+
     return datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
+
+def _download_file_name(url):
+    parsed = urlparse(url)
+    requested_file = parse_qs(parsed.query).get("file", [None])[0]
+    candidate = unquote(requested_file) if requested_file else parsed.path
+    file_name = os.path.basename(candidate)
+    if not file_name:
+        raise ValueError(f"Cannot determine a file name from download URL: {url}")
+    return file_name
+
+
+def _validate_downloaded_archive(path, url):
+    if os.path.getsize(path) == 0:
+        raise ValueError(f"Downloaded dbCAN_seq file is empty: {url}")
+
+    with open(path, "rb") as handle:
+        preview_bytes = handle.read(200)
+    preview = preview_bytes.decode("utf-8", errors="ignore").lstrip().lower()
+
+    if (
+        preview.startswith("<!doctype html")
+        or preview.startswith("<html")
+        or "invalid file" in preview
+    ):
+        raise ValueError(
+            "dbCAN_seq server returned a non-archive response instead of "
+            f"dbCAN_overview.tar.gz. Please check the dbCAN_seq download URL: {url}"
+        )
+    if not preview_bytes.startswith(b"\x1f\x8b"):
+        raise ValueError(
+            "Downloaded dbCAN_seq file is not a gzip archive. The server may have "
+            f"returned an error page. URL: {url}; first bytes: {preview_bytes[:40]!r}"
+        )
+
+
 def download_file(url, save_dir):
+    """Download a dbCAN_seq archive safely and return its final local path."""
     import requests
-    file_name = url.split('/')[-1]
-    print(f'{get_time()} Start downloading {file_name}...')
-    save_path = os.path.join(save_dir, file_name)
-    # remove the old file if exists
-    if os.path.exists(save_path):
-        os.remove(save_path)
-        print(f'{get_time()} Old file removed: {save_path}')
-    # download the file
-    with open(save_path, "wb") as file:
-        response = requests.get(url)
-        file.write(response.content)
-    print(f'{get_time()} {file_name} downloaded!\tSave path: {save_dir+file_name}')
-    
+
+    file_name = _download_file_name(url)
+    save_dir = Path(save_dir)
+    save_dir.mkdir(parents=True, exist_ok=True)
+    save_path = save_dir / file_name
+    temp_path = None
+
+    print(f"{get_time()} Start downloading {file_name}...")
+    try:
+        response = requests.get(
+            url,
+            timeout=60,
+            stream=True,
+            headers={"User-Agent": "MetaX database updater"},
+        )
+        response.raise_for_status()
+
+        with tempfile.NamedTemporaryFile(
+            mode="wb", prefix=f"{file_name}.", suffix=".tmp", dir=save_dir, delete=False
+        ) as handle:
+            temp_path = Path(handle.name)
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    handle.write(chunk)
+
+        if file_name.endswith(".tar.gz"):
+            _validate_downloaded_archive(temp_path, url)
+        elif temp_path.stat().st_size == 0:
+            raise ValueError(f"Downloaded file is empty: {url}")
+
+        os.replace(temp_path, save_path)
+        temp_path = None
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+    print(f"{get_time()} {file_name} downloaded!\tSave path: {save_path}")
+    return str(save_path)
 
 
 def merge_dbcan(file_path):
-    import tarfile
-    from io import StringIO
-
-    print(f'{get_time()} Start reading files...')
-
-    tar = tarfile.open(file_path, "r:gz")
+    """Read dbCAN overview text tables from a validated gzip tar archive."""
+    print(f"{get_time()} Start reading files...")
     dataframes = []
 
-    for member in tar.getmembers():
-        # check if the member is a file
-        if member.isfile() and member.name.endswith('.txt'):
-            # open file
-            f = tar.extractfile(member)
-            content = f.read().decode('utf-8')
-            
-            data = StringIO(content)
-            df = pd.read_csv(data, sep='\t') 
-            dataframes.append(df)
-    
-    print(f'{get_time()} Start concat files...')
-    merged_df = pd.concat(dataframes)
-    tar.close()
+    try:
+        with tarfile.open(file_path, "r:gz") as archive:
+            for member in archive.getmembers():
+                if not (member.isfile() and member.name.endswith(".txt")):
+                    continue
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    continue
+                with extracted:
+                    dataframes.append(
+                        pd.read_csv(StringIO(extracted.read().decode("utf-8")), sep="\t")
+                    )
+    except (OSError, tarfile.TarError) as error:
+        raise ValueError(
+            f"Invalid dbCAN_seq archive: {file_path}. Expected a gzip tar archive containing overview .txt files."
+        ) from error
 
-    new_cols = ['ID','dbcan_EC', 'dbcan_HMMER', 'dbcan_eCAMI', 'dbcan_DIAMOND', 'dbcan_NumOfTools']
-    merged_df.columns = new_cols
-    merged_df.drop(['dbcan_NumOfTools'], axis=1, inplace=True)
-    merged_df['dbcan_HMMER'] = merged_df['dbcan_HMMER'].str.split('(').str[0]
+    if not dataframes:
+        raise ValueError(
+            f"dbCAN_seq archive contains no .txt overview files: {file_path}"
+        )
 
-    print(f'{get_time()} dbcan overview: {merged_df.shape}')
-    
+    print(f"{get_time()} Start concat files...")
+    merged_df = pd.concat(dataframes, ignore_index=True)
+    if len(merged_df.columns) != len(DBCAN_EXPECTED_COLUMNS):
+        raise ValueError(
+            "Unexpected dbCAN_seq overview structure. Expected six columns: "
+            f"{', '.join(DBCAN_EXPECTED_COLUMNS)}; found {len(merged_df.columns)}."
+        )
+
+    merged_df.columns = DBCAN_EXPECTED_COLUMNS
+    merged_df = merged_df.drop(columns=["dbcan_NumOfTools"])
+    merged_df["dbcan_HMMER"] = (
+        merged_df["dbcan_HMMER"].astype("string").str.split("(", n=1).str[0]
+    )
+    print(f"{get_time()} dbCAN overview: {merged_df.shape}")
     return merged_df
 
+
+def _with_id_column(df):
+    if df.empty and len(df.columns) == 0:
+        raise ValueError("Annotation table has no columns.")
+    result = df.copy()
+    result.rename(columns={result.columns[0]: "ID"}, inplace=True)
+    if result.columns.duplicated().any():
+        duplicates = result.columns[result.columns.duplicated()].tolist()
+        raise ValueError(f"Annotation table has duplicate column names: {duplicates}")
+    return result
+
+
 def get_new_anno_df(file_path) -> pd.DataFrame:
-    df = pd.read_csv(file_path, sep='\t')
-    print(f'{get_time()} new annotation: {df.shape}')
-    print(f'{get_time()} new annotation columns: {df.columns}, the first column will be used as ID')
-    # rename the first column to ID
-    df.rename(columns={df.columns[0]: 'ID'}, inplace=True)
+    df = _with_id_column(pd.read_csv(file_path, sep="\t"))
+    print(f"{get_time()} new annotation: {df.shape}")
+    print(f"{get_time()} new annotation columns: {df.columns}, the first column will be used as ID")
     return df
 
-def create_new_database(old_db_path, new_db_path, new_anno_df):
-    # open the database of MGYG and link the merged_df to the database
-    db_path = old_db_path
-    output_path = new_db_path
-    new_anno_df = new_anno_df
 
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
+def _rename_conflicting_columns(old_columns, new_anno_df):
+    new_anno_df = _with_id_column(new_anno_df)
+    replaced_columns = [
+        column for column in new_anno_df.columns if column != "ID" and column in old_columns
+    ]
+    if replaced_columns:
+        print(
+            f"{get_time()} Warning: replacing existing annotation columns with incoming "
+            f"values: {replaced_columns}"
+        )
+    return new_anno_df, replaced_columns
 
-    # open id2annotation table and merge the new_anno_df by ID
-    print(f'{get_time()} open id2annotation table...')
-    # select 1000 rows for test
-    # id2annotation = pd.read_sql_ID("SELECT * FROM id2annotation LIMIT 1000", conn)
-    id2annotation = pd.read_sql_query("SELECT * FROM id2annotation", conn)
-    print(f'{get_time()} merge id2annotation table...')
-    new_df = pd.merge(id2annotation, new_anno_df, on='ID', how='left')
-    new_df = new_df.fillna('-')
-    new_df.set_index('ID', inplace=True)
 
-    # save the new dataframe to a new database file
-    new_conn = sqlite3.connect(output_path)
-    print(f'{get_time()} write new id2annotation table to new database...')
-    new_df.to_sql('id2annotation', new_conn, if_exists='replace', index=True)
-    # copy the id2taxa table from old database to the new database
-    id2taxa = pd.read_sql_query("SELECT * FROM id2taxa", conn)
-    id2taxa.set_index('ID', inplace=True)
-    print(f'{get_time()} write id2taxa table to new database...')
-    id2taxa.to_sql('id2taxa', new_conn, if_exists='replace', index=True)
-    # close the connection
-    conn.close()
-    new_conn.close()
-    print(f'{get_time()} Done!')
+def _write_provenance(new_conn, provenance, match_stats):
+    provenance = provenance or {}
+    new_conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS annotation_update_metadata (
+            update_time TEXT NOT NULL,
+            update_mode TEXT NOT NULL,
+            source_name TEXT,
+            source_url TEXT,
+            old_id_count INTEGER NOT NULL,
+            new_id_count INTEGER NOT NULL,
+            matched_id_count INTEGER NOT NULL,
+            match_rate_old REAL NOT NULL,
+            match_rate_new REAL NOT NULL
+        )
+        """
+    )
+    new_conn.execute(
+        """
+        INSERT INTO annotation_update_metadata (
+            update_time, update_mode, source_name, source_url, old_id_count,
+            new_id_count, matched_id_count, match_rate_old, match_rate_new
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            get_time(),
+            provenance.get("update_mode", "exact_id_merge"),
+            provenance.get("source_name"),
+            provenance.get("source_url"),
+            match_stats["old_n"],
+            match_stats["new_n"],
+            match_stats["matched_n"],
+            match_stats["match_rate_old"],
+            match_stats["match_rate_new"],
+        ),
+    )
+
+
+def create_new_database(old_db_path, new_db_path, new_anno_df, match_stats=None, provenance=None):
+    """Create an updated database without replacing existing annotation fields."""
+    if match_stats is None:
+        match_stats = check_table_match(old_db_path, new_anno_df)
+    with sqlite3.connect(old_db_path) as conn, sqlite3.connect(new_db_path) as new_conn:
+        print(f"{get_time()} open id2annotation table...")
+        id2annotation = pd.read_sql_query("SELECT * FROM id2annotation", conn)
+        new_anno_df, replaced_columns = _rename_conflicting_columns(
+            id2annotation.columns, new_anno_df
+        )
+        if replaced_columns:
+            id2annotation = id2annotation.drop(columns=replaced_columns)
+
+        print(f"{get_time()} merge id2annotation table...")
+        merged_df = pd.merge(
+            id2annotation,
+            new_anno_df,
+            on="ID",
+            how="left",
+            validate="one_to_one",
+        ).fillna("-")
+        merged_df.set_index("ID", inplace=True)
+        print(f"{get_time()} write new id2annotation table to new database...")
+        merged_df.to_sql("id2annotation", new_conn, if_exists="replace", index=True)
+
+        id2taxa = pd.read_sql_query("SELECT * FROM id2taxa", conn)
+        id2taxa.set_index("ID", inplace=True)
+        print(f"{get_time()} write id2taxa table to new database...")
+        id2taxa.to_sql("id2taxa", new_conn, if_exists="replace", index=True)
+        _write_provenance(new_conn, provenance, match_stats)
+
+    print(f"{get_time()} Done!")
+
 
 def check_table_match(old_db_path, new_df):
-    conn = sqlite3.connect(old_db_path)
-    c = conn.cursor()
-    new_df.rename(columns={new_df.columns[0]: 'ID'}, inplace=True)
-    check_name = new_df['ID'].tolist()[0]
-    # check if the check_name is in the old database
-    c.execute("SELECT * FROM id2annotation WHERE ID = ?", (check_name,))
-    result = c.fetchone()
-    conn.close()
-    if result:
-        print(f'{get_time()} Matched!\t{check_name} is in the old database!')
-        return True
-    print(f'{get_time()} The old database does not match the new annotation file!\t{check_name} is not in the old database!')
-    return False
-    
+    """Validate exact protein-ID overlap and return overlap statistics."""
+    new_df = _with_id_column(new_df)
+    with sqlite3.connect(old_db_path) as conn:
+        old_df = pd.read_sql_query("SELECT ID FROM id2annotation", conn)
+
+    old_ids = set(old_df["ID"].dropna().astype(str))
+    new_ids = set(new_df["ID"].dropna().astype(str))
+    matched_ids = old_ids & new_ids
+    old_n = len(old_ids)
+    new_n = len(new_ids)
+    matched_n = len(matched_ids)
+    stats = {
+        "old_n": old_n,
+        "new_n": new_n,
+        "matched_n": matched_n,
+        "match_rate_old": matched_n / old_n if old_n else 0.0,
+        "match_rate_new": matched_n / new_n if new_n else 0.0,
+    }
+    print(
+        f"{get_time()} ID overlap (exact match): old_n={old_n}, new_n={new_n}, "
+        f"matched_n={matched_n}, match_rate_old={stats['match_rate_old']:.2%}, "
+        f"match_rate_new={stats['match_rate_new']:.2%}"
+    )
+    if matched_n == 0:
+        raise ValueError(
+            "The old database and new annotation table have zero matching protein IDs. "
+            "Built-in dbCAN_seq annotations are merged by exact protein ID; they do not "
+            "perform sequence similarity annotation."
+        )
+    if stats["match_rate_old"] < LOW_MATCH_RATE:
+        print(
+            f"{get_time()} Warning: only {stats['match_rate_old']:.2%} of old database "
+            "protein IDs match the incoming annotation table."
+        )
+    return stats
+
+
 def get_built_in_df(built_in_db_name) -> pd.DataFrame:
-    # get the built-in database
-    if built_in_db_name.split(' ')[0] == 'dbCAN':
-        if built_in_db_name == 'dbCAN (HUMAN GUT)':
-            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz"
-        elif built_in_db_name == 'dbCAN (COW RUMEN)':
-            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=COW%20RUMEN/dbCAN_overview.tar.gz"
-        elif built_in_db_name == "dbCAN (MARINE)":
-            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=MARINE/dbCAN_overview.tar.gz"
-        else:
-            raise ValueError(f'Invalid built-in database name: {built_in_db_name}')
-        # download the file to home directory MetaX
-        # build directory if not exist
-        home_dir = os.path.expanduser('~')
-        save_dir = os.path.join(home_dir, 'MetaX')
-        if not os.path.exists(save_dir):
-            os.makedirs(save_dir)
-        # download the file
-        download_file(url, save_dir)
-        # extract the file
-        file_path = os.path.join(save_dir, 'dbCAN_overview.tar.gz')
-        # remove the old file if exists
-        return merge_dbcan(file_path)
-    elif built_in_db_name == 'CAZy':
-        print(f'{get_time()} CAZy is not supported yet!')
-        
-        
-        
-
-
-
-def run_db_update(update_type, tsv_path, old_db_path, new_db_path,  built_in_db_name = None):
+    if built_in_db_name == "CAZy":
+        print(f"{get_time()} CAZy is not supported yet!")
+        return None
     try:
-        if update_type == 'built-in':
+        url = DBCAN_SEQ_URLS[built_in_db_name]
+    except KeyError as error:
+        raise ValueError(f"Invalid built-in database name: {built_in_db_name}") from error
+
+    save_dir = os.path.join(os.path.expanduser("~"), "MetaX")
+    return merge_dbcan(download_file(url, save_dir))
+
+
+def run_db_update(update_type, tsv_path, old_db_path, new_db_path, built_in_db_name=None):
+    try:
+        provenance = {"update_mode": "exact_id_merge"}
+        if update_type == "built-in":
             new_anno_df = get_built_in_df(built_in_db_name)
-        elif update_type == 'custom':
+            provenance.update(
+                source_name=f"dbCAN_seq {built_in_db_name.removeprefix('dbCAN ').strip('()')}",
+                source_url=DBCAN_SEQ_URLS.get(built_in_db_name),
+            )
+        elif update_type == "custom":
             new_anno_df = get_new_anno_df(tsv_path)
+            provenance["source_name"] = os.path.basename(tsv_path)
         else:
-            raise ValueError(f'Invalid type: {update_type}')
-        
-        if check_table_match(old_db_path, new_anno_df):
-            create_new_database(old_db_path, new_db_path, new_anno_df)
-            return True
-        else:
-            raise ValueError('The old database does not match the annotation file!')
-        
-    except Exception as e:
-        print(f'{get_time()} Error: {e}')
-        print(f'{get_time()} Failed!')
-        raise e
-        
+            raise ValueError(f"Invalid type: {update_type}")
+
+        match_stats = check_table_match(old_db_path, new_anno_df)
+        create_new_database(
+            old_db_path,
+            new_db_path,
+            new_anno_df,
+            match_stats,
+            provenance,
+        )
+        return True
+    except Exception as error:
+        print(f"{get_time()} Error: {error}")
+        print(f"{get_time()} Failed!")
+        raise
 
 
-if __name__ == '__main__':
-    print(f'{get_time()} Start...')
-    
-    update_type = 'built-in'
-    # update_type = 'custom'
-    # tsv_path = "overview.txt"
-    old_db_path = "MetaX-human-gut-new.db"
-    new_db_path = "1.0.db"
-    built_in_db_name = 'dbCAN (HUMAN GUT)'
-    
-    run_db_update(update_type = update_type,
-                  tsv_path=None,
-                  old_db_path = old_db_path, 
-                  new_db_path = new_db_path, 
-                  built_in_db_name = built_in_db_name)
-    
-    
+if __name__ == "__main__":
+    print(f"{get_time()} Start...")
+    run_db_update(
+        update_type="built-in",
+        tsv_path=None,
+        old_db_path="MetaX-human-gut-new.db",
+        new_db_path="1.0.db",
+        built_in_db_name="dbCAN (HUMAN GUT)",
+    )

--- a/metax/database_updater/database_updater.py
+++ b/metax/database_updater/database_updater.py
@@ -117,11 +117,11 @@ def get_built_in_df(built_in_db_name) -> pd.DataFrame:
     # get the built-in database
     if built_in_db_name.split(' ')[0] == 'dbCAN':
         if built_in_db_name == 'dbCAN (HUMAN GUT)':
-            url = "https://bcb.unl.edu/dbCAN_seq/download/HUMAN%20GUT/dbCAN_overview.tar.gz"
+            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz"
         elif built_in_db_name == 'dbCAN (COW RUMEN)':
-            url = "https://bcb.unl.edu/dbCAN_seq/download/COW%20RUMEN/dbCAN_overview.tar.gz"
+            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=COW%20RUMEN/dbCAN_overview.tar.gz"
         elif built_in_db_name == "dbCAN (MARINE)":
-            url = "https://bcb.unl.edu/dbCAN_seq/download/MARINE/dbCAN_overview.tar.gz"
+            url = "https://pro.unl.edu/dbCAN_seq/download_file.php?file=MARINE/dbCAN_overview.tar.gz"
         else:
             raise ValueError(f'Invalid built-in database name: {built_in_db_name}')
         # download the file to home directory MetaX

--- a/metax/gui/main_gui.py
+++ b/metax/gui/main_gui.py
@@ -3433,7 +3433,9 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
             # # 存储执行结果到类的属性中
             # self.Qthread_result = result
 
-            if success:
+            if result == FunctionExecutor.CANCELLED_RESULT:
+                self.logger.write_log("Background task cancelled by user", "i")
+            elif success:
                 if result is not None and show_msg:
                     QMessageBox.information(self.MainWindow, 'Result', 'Task completed')
                 elif show_msg:

--- a/metax/gui/main_gui.py
+++ b/metax/gui/main_gui.py
@@ -137,6 +137,7 @@ try:
     from ..database_builder.database_builder_own import build_db
     from ..database_updater.database_updater import run_db_update
     from ..database_builder.database_builder_mag import download_and_build_database
+    from ..database_builder.mgnify_sources import mgnify_catalogue_display_names
 
 except (ImportError, ValueError):
     # Use absolute path to import the module when running directly as a script
@@ -214,6 +215,7 @@ except (ImportError, ValueError):
     from metax.database_builder.database_builder_own import build_db
     from metax.database_updater.database_updater import run_db_update
     from metax.database_builder.database_builder_mag import download_and_build_database
+    from metax.database_builder.mgnify_sources import mgnify_catalogue_display_names
     from metax.workflow_recorder import (
         AnalysisStep,
         WorkflowRecorder,
@@ -310,6 +312,8 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
         super().__init__()
         MainWindow.closeEvent = self.closeEvent
         self.setupUi(MainWindow)
+        self.comboBox_db_type.clear()
+        self.comboBox_db_type.addItems(mgnify_catalogue_display_names())
         self.MainWindow = MainWindow
         # icon_path = os.path.join(os.path.dirname(__file__), "./MetaX_GUI/resources/logo.png")        
         # self.MainWindow.setWindowIcon(QIcon(icon_path))
@@ -4575,10 +4579,10 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
         QMessageBox.information(self.MainWindow, 'Database Type Help', 'All database will be downloaded from MGnify.\nWebsite: https://www.ebi.ac.uk/metagenomics/')
     
     def show_toolButton_db_all_meta_help(self):
-        QMessageBox.information(self.MainWindow, 'Database All Meta Help', 'You may find it in MetaLab-MAG folder or just leave it, we will download it for you')
+        QMessageBox.information(self.MainWindow, 'Database All Meta Help', '[genomes-all_metadata.tsv] or just leave it, we will download it for you')
     
     def show_toolButton_db_anno_folder_help(self):
-        QMessageBox.information(self.MainWindow, 'Database Annotation Folder Help', 'You may find it in MetaLab-MAG folder or just leave it, we will download it for you')
+        QMessageBox.information(self.MainWindow, 'Database Annotation Folder Help', '[annotation_folder] or just leave it, we will download it for you')
 
 
     def show_toolButton_db_update_built_in_help(self):

--- a/metax/gui/main_gui.py
+++ b/metax/gui/main_gui.py
@@ -2185,6 +2185,16 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
         clicked_btn = msgBox.clickedButton()
         
         if clicked_btn in [save_and_close_button, direct_close_button]:
+            if any(not executor.canCloseThread() for executor in self.executors):
+                QMessageBox.warning(
+                    self.MainWindow,
+                    "Task still running",
+                    "A task that cannot be stopped safely is still running. "
+                    "Wait for it to finish before closing MetaX.",
+                )
+                event.ignore()
+                return
+
             try:
                 if clicked_btn == save_and_close_button:
                     self.show_message("Saving settings...", "Closing...")
@@ -2219,7 +2229,9 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
                     
                 # 关闭所有子进程
                 for executor in self.executors:
-                    executor.forceCloseThread()
+                    if not executor.forceCloseThread():
+                        event.ignore()
+                        return
                                 
                 self.logger.write_log("############################## MetaX closed ##############################")
             except Exception as e:

--- a/metax/gui/main_gui.py
+++ b/metax/gui/main_gui.py
@@ -4582,7 +4582,7 @@ class MetaXGUI(ui_main_window.Ui_metaX_main,QtStyleTools):
 
 
     def show_toolButton_db_update_built_in_help(self):
-        QMessageBox.information(self.MainWindow, 'Database Update Built-in Help', 'Some Database are built-in method, you select one of them, and we will download and update it automatically')
+        QMessageBox.information(self.MainWindow, 'Database Update Built-in Help', 'Built-in dbCAN_seq mode merges precomputed annotations by exact protein ID. It does not run sequence similarity search or re-annotate custom proteins. Incoming annotation columns replace existing columns with the same names; MetaX logs a warning listing the replaced columns. For custom protein databases, run dbCAN/run_dbCAN on your own protein FASTA, then import a TSV table with matching MetaX protein IDs.')
     def show_toolButton_db_update_table_help(self):
         QMessageBox.information(self.MainWindow, 'Database Update Table Help', 'Extend the database by adding new database to the database table\n\nMake sure the column separator is tab\n\nMake sure the first column is Protein name and other columns are function annotation')
 

--- a/metax/gui/metax_gui/generic_thread.py
+++ b/metax/gui/metax_gui/generic_thread.py
@@ -8,6 +8,8 @@ import sys
 import re
 import os
 import logging
+import inspect
+import threading
 
 class EmittingStream(QObject):
     text_written = pyqtSignal(str)
@@ -36,12 +38,15 @@ class LoggingHandler(logging.Handler):
 
 class FunctionExecutor(QMainWindow):
     finished = pyqtSignal(object, bool)  # to emit the result and whether the function was successful
+    CANCELLED_RESULT = "Task cancelled by user."
 
     def __init__(self, function, *args, logger=None, **kwargs):
         super().__init__()
 
         self.function_running = True  # set flag to indicate that the function is running
         self.logger = logger 
+        self.cancel_event = threading.Event()
+        self.supports_cancellation = self._supports_cancellation(function)
 
         self.setWindowTitle('Progress')
         # set the size of the window as 1/3 of the screen
@@ -63,6 +68,8 @@ class FunctionExecutor(QMainWindow):
         self.function = function
         self.args = args
         self.kwargs = kwargs
+        if self.supports_cancellation:
+            self.kwargs.setdefault("cancel_event", self.cancel_event)
         
         self.stream_out = EmittingStream(sys.stdout)
         self.stream_err = EmittingStream(sys.stderr)
@@ -88,6 +95,20 @@ class FunctionExecutor(QMainWindow):
 
         self.thread.start()
 
+    @staticmethod
+    def _supports_cancellation(function):
+        """Return whether a worker accepts the cooperative cancellation event."""
+        try:
+            parameters = inspect.signature(function).parameters.values()
+        except (TypeError, ValueError):
+            return False
+
+        return any(
+            parameter.name == "cancel_event"
+            or parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters
+        )
+
             
     def run_function(self):
         sys.stdout = self.stream_out
@@ -96,6 +117,11 @@ class FunctionExecutor(QMainWindow):
         try:
             self.result = self.function(*self.args, **self.kwargs)
         except Exception as e:
+            if self.cancel_event.is_set():
+                self.result = self.CANCELLED_RESULT
+                success = False
+                return
+
             import traceback
             error_message = traceback.format_exc()
             sys.__stderr__.write(error_message)
@@ -111,6 +137,9 @@ class FunctionExecutor(QMainWindow):
             current_function = self.function.__name__
             self.result = f"Error in {current_function}\n\n{str(e)}"
         finally:
+            if self.cancel_event.is_set():
+                self.result = self.CANCELLED_RESULT
+                success = False
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
             self.finished.emit(self.result, success)
@@ -150,9 +179,8 @@ class FunctionExecutor(QMainWindow):
         
 
     def forceCloseThread(self):
-        if self.thread.isRunning():
-            self.thread.terminate()  # 强制结束线程
-            self.thread.wait()  # 等待线程结束
+        if self.thread.isRunning() and self.supports_cancellation:
+            self.cancel_event.set()
             
             
 
@@ -160,16 +188,16 @@ class FunctionExecutor(QMainWindow):
         if self.function_running:
             # 如果函数仍在运行，询问用户是否真的想要关闭窗口
             reply = QMessageBox.question(self, 'Message',
-                                        'Are you sure you want to stop the process and close the window?',
+                                        ('Are you sure you want to stop the process and close the window?'
+                                         if self.supports_cancellation else
+                                         'This task cannot be stopped safely and will continue in the background. Close the progress window?'),
                                         QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
             if reply == QMessageBox.Yes:
-                self.thread.terminate()  # 强制结束线程
-                # 记录终止信息到logger
+                if self.supports_cancellation:
+                    self.cancel_event.set()
                 if self.logger:
-                    self.logger.write_log("Process was manually terminated by user", 'w')
-                # return success as False, result as None
-                self.finished.emit("Process terminated.", False)
+                    self.logger.write_log("Process cancellation requested by user", 'w')
 
                 event.accept()
             else:

--- a/metax/gui/metax_gui/generic_thread.py
+++ b/metax/gui/metax_gui/generic_thread.py
@@ -178,9 +178,25 @@ class FunctionExecutor(QMainWindow):
         # self.close()
         
 
+    def canCloseThread(self):
+        """Return whether closing the application can safely stop this worker."""
+        return not self.thread.isRunning() or self.supports_cancellation
+
     def forceCloseThread(self):
-        if self.thread.isRunning() and self.supports_cancellation:
-            self.cancel_event.set()
+        """Cancel a running worker and wait until its QThread has stopped.
+
+        QThread instances must not outlive the Qt application.  Workers that do
+        not support cooperative cancellation are reported to the caller so the
+        application can keep running instead of tearing down underneath them.
+        """
+        if not self.thread.isRunning():
+            return True
+        if not self.supports_cancellation:
+            return False
+
+        self.cancel_event.set()
+        self.thread.wait()
+        return not self.thread.isRunning()
             
             
 

--- a/metax/utils/version.py
+++ b/metax/utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 API_version = '8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "openpyxl",
     "pyproject-toml>=0.0.10",
     "PyYAML>=6.0",
+    "requests>=2.31.0",
     "Jinja2>=3.1",
     "joblib>=1.3.0",
     "statsmodels",

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ adjustText>=1.1.1
 openpyxl
 pyproject-toml>=0.0.10
 PyYAML>=6.0
+requests>=2.31.0
 Jinja2>=3.1
 joblib>=1.3.0
 statsmodels

--- a/tests/test_database_updater.py
+++ b/tests/test_database_updater.py
@@ -1,0 +1,189 @@
+import io
+import sqlite3
+import sys
+import tarfile
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from metax.database_updater import database_updater
+
+
+class MockResponse:
+    def __init__(self, content, status_error=None):
+        self.content = content
+        self.status_error = status_error
+
+    def raise_for_status(self):
+        if self.status_error:
+            raise self.status_error
+
+    def iter_content(self, chunk_size):
+        yield self.content
+
+
+def _mock_requests(monkeypatch, response):
+    monkeypatch.setitem(
+        sys.modules,
+        "requests",
+        SimpleNamespace(get=lambda *args, **kwargs: response),
+    )
+
+
+def _create_database(path, annotation=None):
+    if annotation is None:
+        annotation = pd.DataFrame(
+            {"ID": ["protein_1", "protein_2"], "old_annotation": ["old_1", "old_2"]}
+        )
+    id2taxa = pd.DataFrame(
+        {"ID": annotation["ID"], "taxa": ["taxa_1", "taxa_2"][: len(annotation)]}
+    )
+    with sqlite3.connect(path) as connection:
+        annotation.to_sql("id2annotation", connection, index=False)
+        id2taxa.to_sql("id2taxa", connection, index=False)
+
+
+def _dbcan_archive_bytes():
+    table = (
+        "protein\tEC\tHMMER\teCAMI\tDIAMOND\tNumOfTools\n"
+        "protein_1\t1.1.1.1\tGH1(1-10)\tGH1\tGH1\t4\n"
+    ).encode()
+    archive = io.BytesIO()
+    with tarfile.open(fileobj=archive, mode="w:gz") as tar:
+        info = tarfile.TarInfo("overview.txt")
+        info.size = len(table)
+        tar.addfile(info, io.BytesIO(table))
+    return archive.getvalue()
+
+
+@pytest.mark.parametrize("content", [b"<html>service unavailable</html>", b"Invalid file"])
+def test_download_file_rejects_server_error_content(monkeypatch, tmp_path, content):
+    _mock_requests(monkeypatch, MockResponse(content))
+
+    with pytest.raises(ValueError, match="non-archive response"):
+        database_updater.download_file(
+            "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz",
+            tmp_path,
+        )
+
+
+def test_download_file_rejects_empty_response(monkeypatch, tmp_path):
+    _mock_requests(monkeypatch, MockResponse(b""))
+
+    with pytest.raises(ValueError, match="empty"):
+        database_updater.download_file(
+            "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz",
+            tmp_path,
+        )
+
+
+def test_download_file_and_merge_valid_archive(monkeypatch, tmp_path):
+    _mock_requests(monkeypatch, MockResponse(_dbcan_archive_bytes()))
+
+    path = database_updater.download_file(
+        "https://pro.unl.edu/dbCAN_seq/download_file.php?file=HUMAN%20GUT/dbCAN_overview.tar.gz",
+        tmp_path,
+    )
+    result = database_updater.merge_dbcan(path)
+
+    assert result.to_dict("records") == [
+        {
+            "ID": "protein_1",
+            "dbcan_EC": "1.1.1.1",
+            "dbcan_HMMER": "GH1",
+            "dbcan_eCAMI": "GH1",
+            "dbcan_DIAMOND": "GH1",
+        }
+    ]
+
+
+def test_check_table_match_rejects_zero_overlap(tmp_path):
+    old_db_path = tmp_path / "old.db"
+    _create_database(old_db_path)
+
+    with pytest.raises(ValueError, match="zero matching protein IDs"):
+        database_updater.check_table_match(
+            old_db_path, pd.DataFrame({"ID": ["different_protein"]})
+        )
+
+
+def test_check_table_match_reports_partial_overlap(tmp_path):
+    old_db_path = tmp_path / "old.db"
+    _create_database(old_db_path)
+
+    stats = database_updater.check_table_match(
+        old_db_path, pd.DataFrame({"ID": ["protein_1", "new_protein"]})
+    )
+
+    assert stats == {
+        "old_n": 2,
+        "new_n": 2,
+        "matched_n": 1,
+        "match_rate_old": 0.5,
+        "match_rate_new": 0.5,
+    }
+
+
+def test_create_new_database_replaces_all_conflicting_annotations(tmp_path):
+    old_db_path = tmp_path / "old.db"
+    new_db_path = tmp_path / "updated.db"
+    _create_database(
+        old_db_path,
+        pd.DataFrame(
+            {
+                "ID": ["protein_1", "protein_2"],
+                "old_annotation": ["old_1", "old_2"],
+                "dbcan_EC": ["old_EC_1", "old_EC_2"],
+            }
+        ),
+    )
+    incoming = pd.DataFrame(
+        {"ID": ["protein_1", "protein_2"], "old_annotation": ["new_1", "new_2"], "dbcan_EC": ["EC1", "EC2"]}
+    )
+    stats = database_updater.check_table_match(old_db_path, incoming)
+
+    database_updater.create_new_database(
+        old_db_path,
+        new_db_path,
+        incoming,
+        stats,
+        {"source_name": "test source", "source_url": "https://example.test", "update_mode": "exact_id_merge"},
+    )
+
+    with sqlite3.connect(new_db_path) as connection:
+        annotations = pd.read_sql_query("SELECT * FROM id2annotation", connection)
+        taxa = pd.read_sql_query("SELECT * FROM id2taxa", connection)
+        provenance = pd.read_sql_query("SELECT * FROM annotation_update_metadata", connection)
+
+    assert annotations["old_annotation"].tolist() == ["new_1", "new_2"]
+    assert annotations["dbcan_EC"].tolist() == ["EC1", "EC2"]
+    assert "old_annotation_update" not in annotations
+    assert "dbcan_seq_EC" not in annotations
+    assert taxa.to_dict("records") == [
+        {"ID": "protein_1", "taxa": "taxa_1"},
+        {"ID": "protein_2", "taxa": "taxa_2"},
+    ]
+    assert provenance.loc[0, "source_name"] == "test source"
+    assert provenance.loc[0, "matched_id_count"] == 2
+
+
+def test_run_db_update_custom_tsv_executes_full_update_workflow(tmp_path):
+    old_db_path = tmp_path / "old.db"
+    new_db_path = tmp_path / "updated.db"
+    tsv_path = tmp_path / "custom_annotations.tsv"
+    _create_database(old_db_path)
+    pd.DataFrame(
+        {"protein_name": ["protein_1", "protein_2"], "new_annotation": ["new_1", "new_2"]}
+    ).to_csv(tsv_path, sep="\t", index=False)
+
+    assert database_updater.run_db_update(
+        "custom", str(tsv_path), str(old_db_path), str(new_db_path)
+    )
+
+    with sqlite3.connect(new_db_path) as connection:
+        annotations = pd.read_sql_query("SELECT * FROM id2annotation", connection)
+        provenance = pd.read_sql_query("SELECT * FROM annotation_update_metadata", connection)
+    assert annotations["old_annotation"].tolist() == ["old_1", "old_2"]
+    assert annotations["new_annotation"].tolist() == ["new_1", "new_2"]
+    assert provenance.loc[0, "update_mode"] == "exact_id_merge"

--- a/tests/test_mgnify_sources.py
+++ b/tests/test_mgnify_sources.py
@@ -2,6 +2,7 @@ import inspect
 import threading
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from metax.database_builder import database_builder_mag, download_mgyg_faa
@@ -159,6 +160,52 @@ def test_database_download_honours_a_cancellation_request(tmp_path):
         database_builder_mag.download_and_build_database(
             str(tmp_path), "MetaX.db", "human-gut", cancel_event=cancel_event
         )
+
+
+def test_cancelled_annotation_download_leaves_no_final_or_partial_file(monkeypatch, tmp_path):
+    cancel_event = threading.Event()
+
+    class Response:
+        def read(self, _):
+            cancel_event.set()
+            return b"partial annotation"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(database_builder_mag.urllib.request, "urlopen", lambda *_, **__: Response())
+
+    with pytest.raises(database_builder_mag.DownloadCancelled):
+        database_builder_mag.download_with_retry(
+            "https://example.test/MGYG000001_eggNOG.tsv",
+            tmp_path,
+            cancel_event=cancel_event,
+        )
+
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_annotation_database_build_honours_cancellation_before_writing(monkeypatch, tmp_path):
+    annotation_dir = tmp_path / "id2annotation"
+    annotation_dir.mkdir()
+    (annotation_dir / "annotation.tsv").write_text("ID\tannotation\nprotein_1\tA\n", encoding="utf-8")
+    cancel_event = threading.Event()
+
+    def cancel_after_read(*_):
+        cancel_event.set()
+        return pd.DataFrame({"ID": ["protein_1"], "annotation": ["A"]})
+
+    monkeypatch.setattr(database_builder_mag, "read_file", cancel_after_read)
+
+    with pytest.raises(database_builder_mag.DownloadCancelled):
+        database_builder_mag.build_id2annotation_db(
+            tmp_path, "MetaX.db", cancel_event=cancel_event
+        )
+
+    assert not (tmp_path / "MetaX.db").exists()
 
 
 def test_progress_window_does_not_force_terminate_worker_threads():

--- a/tests/test_mgnify_sources.py
+++ b/tests/test_mgnify_sources.py
@@ -36,6 +36,38 @@ def test_new_catalogues_are_supported_but_marine_eukaryotes_is_not():
     assert "marine-eukaryotes" not in DB_URLS
 
 
+def test_marine_sediment_uses_the_verified_hyphenated_ftp_path(monkeypatch):
+    base_url = DB_URLS["marine-sediment"]["base_url"]
+    assert base_url.endswith("/marine-sediment/v1.0")
+
+    checked_urls = []
+
+    class Response:
+        status = 200
+
+        def read(self, _):
+            return b"Species_rep\tLineage\n"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def fake_urlopen(url, timeout):
+        checked_urls.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr("metax.database_builder.mgnify_sources.urllib.request.urlopen", fake_urlopen)
+
+    validate_mgnify_source("marine-sediment", check_catalogue=True)
+
+    assert [url for url, _ in checked_urls] == [
+        "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine-sediment/v1.0/genomes-all_metadata.tsv",
+        "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/marine-sediment/v1.0/species_catalogue/",
+    ]
+
+
 def test_database_builders_share_the_single_source_definition():
     assert database_builder_mag.DB_URLS is DB_URLS
     assert download_mgyg_faa.DB_URLS is DB_URLS
@@ -117,6 +149,37 @@ def test_validate_mgnify_source_checks_metadata_and_optional_catalogue(monkeypat
     assert [url for url, _ in checked_urls] == [
         "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/genomes-all_metadata.tsv",
         "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/species_catalogue/",
+    ]
+
+
+@pytest.mark.parametrize("db_type", sorted(DB_URLS))
+def test_every_mgnify_source_builds_metadata_and_catalogue_urls(monkeypatch, db_type):
+    checked_urls = []
+
+    class Response:
+        status = 200
+
+        def read(self, _):
+            return b"Species_rep\tLineage\n"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def fake_urlopen(url, timeout):
+        checked_urls.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr("metax.database_builder.mgnify_sources.urllib.request.urlopen", fake_urlopen)
+
+    source = DB_URLS[db_type]
+    validate_mgnify_source(db_type, check_catalogue=True)
+
+    assert [url for url, _ in checked_urls] == [
+        f"{source['base_url']}/{source['metadata']}",
+        f"{source['base_url']}/{source['catalogue']}/",
     ]
 
 
@@ -219,3 +282,16 @@ def test_progress_window_does_not_force_terminate_worker_threads():
 
     assert "self.thread.terminate()" not in generic_thread_source
     assert "self.cancel_event.set()" in generic_thread_source
+
+
+def test_application_shutdown_waits_for_cancellable_workers_and_blocks_others():
+    root = Path(__file__).resolve().parents[1]
+    generic_thread_source = (root / "metax" / "gui" / "metax_gui" / "generic_thread.py").read_text(
+        encoding="utf-8"
+    )
+    main_gui_source = (root / "metax" / "gui" / "main_gui.py").read_text(encoding="utf-8")
+
+    assert "def canCloseThread(self):" in generic_thread_source
+    assert "self.thread.wait()" in generic_thread_source
+    assert "if not self.supports_cancellation:\n            return False" in generic_thread_source
+    assert "if any(not executor.canCloseThread() for executor in self.executors):" in main_gui_source

--- a/tests/test_mgnify_sources.py
+++ b/tests/test_mgnify_sources.py
@@ -1,4 +1,5 @@
 import inspect
+import threading
 from pathlib import Path
 
 import pytest
@@ -148,3 +149,26 @@ def test_validate_mgnify_source_rejects_metadata_without_required_columns(monkey
 
     with pytest.raises(ValueError, match="missing required columns Lineage"):
         validate_mgnify_source("human-gut")
+
+
+def test_database_download_honours_a_cancellation_request(tmp_path):
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    with pytest.raises(database_builder_mag.DownloadCancelled):
+        database_builder_mag.download_and_build_database(
+            str(tmp_path), "MetaX.db", "human-gut", cancel_event=cancel_event
+        )
+
+
+def test_progress_window_does_not_force_terminate_worker_threads():
+    generic_thread_source = (
+        Path(__file__).resolve().parents[1]
+        / "metax"
+        / "gui"
+        / "metax_gui"
+        / "generic_thread.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self.thread.terminate()" not in generic_thread_source
+    assert "self.cancel_event.set()" in generic_thread_source

--- a/tests/test_mgnify_sources.py
+++ b/tests/test_mgnify_sources.py
@@ -1,0 +1,150 @@
+import inspect
+from pathlib import Path
+
+import pytest
+
+from metax.database_builder import database_builder_mag, download_mgyg_faa
+from metax.database_builder.mgnify_sources import (
+    DB_URLS,
+    GUI_CATALOGUE_PRIORITY,
+    mgnify_catalogue_display_names,
+    validate_mgnify_source,
+)
+
+
+NEW_CATALOGUES = {
+    "barley-rhizosphere",
+    "human-skin",
+    "maize-rhizosphere",
+    "marine-sediment",
+    "soil",
+    "tomato-rhizosphere",
+}
+
+
+def test_mgnify_sources_have_required_https_urls():
+    for db_type, source in DB_URLS.items():
+        assert source["base_url"].startswith("https://"), db_type
+        assert source["metadata"]
+        assert source["catalogue"]
+
+
+def test_new_catalogues_are_supported_but_marine_eukaryotes_is_not():
+    assert NEW_CATALOGUES.issubset(DB_URLS)
+    assert "marine-eukaryotes" not in DB_URLS
+
+
+def test_database_builders_share_the_single_source_definition():
+    assert database_builder_mag.DB_URLS is DB_URLS
+    assert download_mgyg_faa.DB_URLS is DB_URLS
+
+    for module in (database_builder_mag, download_mgyg_faa):
+        source = Path(inspect.getfile(module)).read_text(encoding="utf-8")
+        assert "DB_URLS = {" not in source
+
+
+def test_cli_database_type_choices_and_help_match_sources():
+    parser = database_builder_mag.build_parser()
+    db_type_action = next(action for action in parser._actions if action.dest == "db_type")
+
+    assert tuple(db_type_action.choices) == tuple(sorted(DB_URLS))
+    help_text = "".join(parser.format_help().split())
+    for db_type in DB_URLS:
+        assert db_type in help_text
+
+
+def test_gui_catalogue_display_list_comes_from_all_supported_sources():
+    labels = mgnify_catalogue_display_names()
+    gui_source = (
+        Path(__file__).resolve().parents[1] / "metax" / "gui" / "main_gui.py"
+    ).read_text(encoding="utf-8")
+
+    assert all(db_type in labels[index] for index, db_type in enumerate(GUI_CATALOGUE_PRIORITY))
+    assert labels[len(GUI_CATALOGUE_PRIORITY):] == sorted(labels[len(GUI_CATALOGUE_PRIORITY):])
+    assert all(db_type in " ".join(labels) for db_type in NEW_CATALOGUES)
+    assert "marine-eukaryotes" not in " ".join(labels)
+    assert "self.comboBox_db_type.addItems(mgnify_catalogue_display_names())" in gui_source
+
+
+@pytest.mark.parametrize(
+    ("mgyg_id", "db_type", "expected_eggnog", "expected_faa"),
+    [
+        (
+            "MGYG000001234",
+            "human-gut",
+            "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/species_catalogue/MGYG0000012/MGYG000001234/genome/MGYG000001234_eggNOG.tsv",
+            "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/species_catalogue/MGYG0000012/MGYG000001234/genome/MGYG000001234.faa",
+        ),
+        (
+            "MGYG000123456.1",
+            "mouse-gut",
+            "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/mouse-gut/v1.0/species_catalogue/MGYG0001234/MGYG000123456.1/genome/MGYG000123456.1_eggNOG.tsv",
+            "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/mouse-gut/v1.0/species_catalogue/MGYG0001234/MGYG000123456.1/genome/MGYG000123456.1.faa",
+        ),
+    ],
+)
+def test_create_download_list_preserves_existing_mgnify_paths(
+    mgyg_id, db_type, expected_eggnog, expected_faa
+):
+    assert database_builder_mag.create_download_list([mgyg_id], db_type) == [expected_eggnog]
+    assert download_mgyg_faa.create_download_list([mgyg_id], db_type) == [expected_faa]
+
+
+def test_validate_mgnify_source_checks_metadata_and_optional_catalogue(monkeypatch):
+    checked_urls = []
+
+    class Response:
+        status = 200
+
+        def read(self, _):
+            return b"Species_rep\tLineage\n"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    def fake_urlopen(url, timeout):
+        checked_urls.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr("metax.database_builder.mgnify_sources.urllib.request.urlopen", fake_urlopen)
+
+    assert validate_mgnify_source("human-gut", check_catalogue=True) is DB_URLS["human-gut"]
+    assert [url for url, _ in checked_urls] == [
+        "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/genomes-all_metadata.tsv",
+        "https://ftp.ebi.ac.uk/pub/databases/metagenomics/mgnify_genomes/human-gut/v2.0.2/species_catalogue/",
+    ]
+
+
+def test_validate_mgnify_source_reports_unavailable_url(monkeypatch):
+    def unavailable(*_, **__):
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr("metax.database_builder.mgnify_sources.urllib.request.urlopen", unavailable)
+
+    with pytest.raises(RuntimeError, match="MGnify metadata URL is unavailable.*human-gut"):
+        validate_mgnify_source("human-gut")
+
+
+def test_validate_mgnify_source_rejects_metadata_without_required_columns(monkeypatch):
+    class Response:
+        status = 200
+
+        def read(self, _):
+            return b"Species_rep\tGenome\n"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+    monkeypatch.setattr(
+        "metax.database_builder.mgnify_sources.urllib.request.urlopen",
+        lambda *_, **__: Response(),
+    )
+
+    with pytest.raises(ValueError, match="missing required columns Lineage"):
+        validate_mgnify_source("human-gut")


### PR DESCRIPTION
This pull request introduces significant improvements to the MGnify database builder in MetaX, with a focus on supporting user cancellation during long-running downloads and database builds, refactoring to centralize supported catalogues, and enhancing documentation for clarity. The changes also improve robustness and maintainability by modularizing the code and updating user-facing guidance.

**Key changes include:**

### User Cancellation and Robustness

* Added support for user-initiated cancellation of MGnify database downloads and builds by introducing a `cancel_event` parameter throughout the workflow and raising a custom `DownloadCancelled` exception when triggered. This ensures that long-running operations can be safely interrupted without leaving partial files or inconsistent databases. (`metax/database_builder/database_builder_mag.py`) [[1]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaR16-R77) [[2]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL126-R122) [[3]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaR143) [[4]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL191-R179) [[5]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL210-R218) [[6]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL238-R238) [[7]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL286-R284) [[8]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL297-R306) [[9]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaR318) [[10]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaR345-R350) [[11]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL397-R448)

* Improved download integrity by writing to temporary files and only moving them into place upon successful completion, ensuring that interrupted or failed downloads do not leave corrupt files. (`metax/database_builder/database_builder_mag.py`)

### Refactoring and Catalog Support

* Centralized the list of supported MGnify catalogues by importing `DB_URLS` from a dedicated `mgnify_sources` module, simplifying maintenance and future catalogue updates. (`metax/database_builder/database_builder_mag.py`)

* Updated the script header and documentation to reflect the new centralized catalogue support and clarify the rationale for enabling/disabling specific catalogues (e.g., `marine-eukaryotes` is excluded by default). (`metax/database_builder/database_builder_mag.py`, `Docs/MetaX_Cookbook.md`) [[1]](diffhunk://#diff-57cf193dff811a68e68325b33290c32b320009ff3be1ead0ba50c7f5e25bdfcaL3-R3) [[2]](diffhunk://#diff-46157e208ad573c846f352115a7b14223638f7e8cd9b215a257b31c08ef55e39R714-R715)

### Documentation Improvements

* Enhanced documentation for the Database Builder and Database Updater modules, providing detailed explanations of built-in modes, annotation merging behavior, and steps for custom protein database annotation. This helps users understand both the capabilities and limitations of built-in annotation sources. (`Docs/MetaX_Cookbook.md`, `Docs/index.html`) [[1]](diffhunk://#diff-46157e208ad573c846f352115a7b14223638f7e8cd9b215a257b31c08ef55e39L765-R767) [[2]](diffhunk://#diff-5b424626e0cba25c74c9adf6ca937bd5682d997815cadfc41e7963c57de2deeaL1906-R1906)

### CLI and Usability

* Refactored command-line interface code to improve help output and argument parsing, making the tool easier to use and extend. (`metax/database_builder/database_builder_mag.py`)

These changes collectively make the database builder more user-friendly, robust, and maintainable, while ensuring users have clear guidance and control over the database construction process.