### PR TITLE
Allow skipping units without genomes at selected threshold

### DIFF
--- a/metax/gui/unit_specific_settings_dialog.py
+++ b/metax/gui/unit_specific_settings_dialog.py
@@ -119,6 +119,7 @@ def validate_genome_selection_manifest_for_gui(
     genome_threshold: str = "auto",
     input_sample_col_prefix: str | None = None,
     on_missing_sample: str = "error",
+    on_empty_unit: str = "warn-skip",
     diann_intensity_col: str | None = None,
     digested_genome_folders: str | list[str] | None = None,
 ) -> UnitSpecificManifestValidationResult:
@@ -127,6 +128,14 @@ def validate_genome_selection_manifest_for_gui(
         return UnitSpecificManifestValidationResult(
             False,
             "On missing sample must be 'error' or 'warn-skip'.",
+            [],
+            {},
+            [],
+        )
+    if on_empty_unit not in {"error", "warn-skip"}:
+        return UnitSpecificManifestValidationResult(
+            False,
+            "On empty unit must be 'error' or 'warn-skip'.",
             [],
             {},
             [],
@@ -147,6 +156,22 @@ def validate_genome_selection_manifest_for_gui(
         manifest = load_genome_selection_manifest(manifest_path, genome_threshold=threshold_arg, strict=True)
     except Exception as exc:
         return UnitSpecificManifestValidationResult(False, f"Manifest validation failed:\n{exc}", [], {}, [])
+
+    empty_genome_units = [
+        unit.analysis_unit_id
+        for unit in manifest.units.values()
+        if not unit.genome_ids
+    ]
+    if empty_genome_units and on_empty_unit == "error":
+        unit_id = empty_genome_units[0]
+        return UnitSpecificManifestValidationResult(
+            False,
+            f"Manifest validation failed:\nUnit {unit_id!r} has no genomes at selected "
+            f"threshold {manifest.selected_genome_threshold}",
+            [],
+            {},
+            [],
+        )
 
     manifest_samples = _all_manifest_samples(manifest)
     mapped_samples: dict[str, str] = {}
@@ -318,6 +343,11 @@ def validate_genome_selection_manifest_for_gui(
             )
         digest_status = f"valid ({len(selected_genomes)} selected genome files)"
     provenance_warning = "\n".join(f"Manifest warning: {item}" for item in manifest.warnings)
+    empty_unit_warning = ""
+    if empty_genome_units:
+        empty_unit_warning = (
+            "Empty genome units to skip: " + ", ".join(empty_genome_units)
+        )
     message = (
         "Manifest schema: valid\n"
         f"Manifest mode: {manifest.unit_definition.get('mode')}\n"
@@ -331,6 +361,7 @@ def validate_genome_selection_manifest_for_gui(
         f"Missing samples: {missing_text}\n"
         "Per-unit summary:\n"
         + "\n".join(unit_lines)
+        + ("\n" + empty_unit_warning if empty_unit_warning else "")
         + ("\n" + provenance_warning if provenance_warning else "")
     )
     ok = not missing_samples or on_missing_sample == "warn-skip"
@@ -431,6 +462,7 @@ class ManifestSettingsDialog(QtWidgets.QDialog):
             genome_threshold=self._config.genome_threshold,
             input_sample_col_prefix=self.lineEdit_input_prefix.text().strip() or None,
             on_missing_sample=self.comboBox_on_missing_sample.currentText().strip(),
+            on_empty_unit=self.comboBox_on_empty_unit.currentText().strip(),
             diann_intensity_col=self.diann_intensity_col,
             digested_genome_folders=self.digested_genome_folders,
         )

--- a/metax/gui/unit_specific_settings_dialog.py
+++ b/metax/gui/unit_specific_settings_dialog.py
@@ -102,9 +102,15 @@ def _read_long_format_run_columns(peptide_table_path: str) -> list[str]:
     return [str(value) for value in pc.unique(run_column).to_pylist() if value is not None]
 
 
-def _all_manifest_samples(manifest) -> list[str]:
+def _manifest_samples(
+    manifest,
+    *,
+    include_empty_genome_units: bool = True,
+) -> list[str]:
     samples: list[str] = []
     for unit in manifest.units.values():
+        if not include_empty_genome_units and not unit.genome_ids:
+            continue
         for sample in unit.sample_columns:
             if sample not in samples:
                 samples.append(sample)
@@ -173,7 +179,11 @@ def validate_genome_selection_manifest_for_gui(
             [],
         )
 
-    manifest_samples = _all_manifest_samples(manifest)
+    manifest_samples = _manifest_samples(manifest)
+    required_manifest_samples = _manifest_samples(
+        manifest,
+        include_empty_genome_units=False,
+    )
     mapped_samples: dict[str, str] = {}
     missing_samples: list[str] = []
     header_validation_skipped = False
@@ -188,7 +198,7 @@ def validate_genome_selection_manifest_for_gui(
             "before validating the manifest.",
             manifest_samples,
             {},
-            manifest_samples,
+            required_manifest_samples,
         )
     if peptide_table_path:
         if not Path(peptide_table_path).is_file():
@@ -197,7 +207,7 @@ def validate_genome_selection_manifest_for_gui(
                 f"Peptide table not found:\n{peptide_table_path}",
                 manifest_samples,
                 {},
-                manifest_samples,
+                required_manifest_samples,
             )
         try:
             peptide_columns = _read_peptide_table_header_columns(peptide_table_path, peptide_table_separator)
@@ -207,7 +217,7 @@ def validate_genome_selection_manifest_for_gui(
                 f"Could not read peptide table header:\n{exc}",
                 manifest_samples,
                 {},
-                manifest_samples,
+                required_manifest_samples,
             )
 
         if peptide_columns is None:
@@ -220,7 +230,7 @@ def validate_genome_selection_manifest_for_gui(
                     f"Peptide column {peptide_col!r} was not found in the peptide table header.",
                     manifest_samples,
                     {},
-                    manifest_samples,
+                    required_manifest_samples,
                 )
             candidate_sample_columns = peptide_columns
             if (
@@ -252,14 +262,14 @@ def validate_genome_selection_manifest_for_gui(
                         f"Could not read DIA-NN Run values from the parquet file:\n{exc}",
                         manifest_samples,
                         {},
-                        manifest_samples,
+                        required_manifest_samples,
                     )
             try:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", UserWarning)
                     mapped_samples = resolve_manifest_sample_columns(
                         peptide_columns=candidate_sample_columns,
-                        manifest_sample_columns=manifest_samples,
+                        manifest_sample_columns=required_manifest_samples,
                         output_sample_col_prefix="Intensity_",
                         input_sample_col_prefix=input_sample_col_prefix or None,
                         on_missing="warn-skip",
@@ -272,7 +282,11 @@ def validate_genome_selection_manifest_for_gui(
                     mapped_samples,
                     missing_samples,
                 )
-            missing_samples = [sample for sample in manifest_samples if sample not in mapped_samples]
+            missing_samples = [
+                sample
+                for sample in required_manifest_samples
+                if sample not in mapped_samples
+            ]
             if missing_samples and on_missing_sample == "error":
                 example_count = min(8, len(missing_samples))
                 missing_examples = ", ".join(missing_samples[:example_count])
@@ -288,7 +302,7 @@ def validate_genome_selection_manifest_for_gui(
                 return UnitSpecificManifestValidationResult(
                     False,
                     "Manifest sample-column validation failed.\n"
-                    f"Mapped samples: {len(mapped_samples)}/{len(manifest_samples)}\n"
+                    f"Mapped samples: {len(mapped_samples)}/{len(required_manifest_samples)}\n"
                     f"Missing samples: {len(missing_samples)}\n"
                     f"Examples: {missing_examples}"
                     f"{long_format_hint}",
@@ -355,6 +369,7 @@ def validate_genome_selection_manifest_for_gui(
         f"Selected genome threshold: {manifest.selected_genome_threshold}\n"
         f"Units: {len(manifest.units)}\n"
         f"Manifest samples: {len(manifest_samples)}\n"
+        f"Required peptide table samples: {len(required_manifest_samples)}\n"
         f"Genome digest source: {digest_status}\n"
         + ("\n".join(header_status_lines) + "\n" if header_status_lines else "")
         + f"Mapped peptide table samples: {mapped_text}\n"

--- a/metax/peptide_annotator/unit_specific_manifest.py
+++ b/metax/peptide_annotator/unit_specific_manifest.py
@@ -244,10 +244,6 @@ def load_genome_selection_manifest(
             allow_empty=True,
         )
         genome_ids = q005 if selected_genome_key == "genome_ids_q005" else q001
-        if not genome_ids:
-            raise ValueError(
-                f"Unit {analysis_unit_id!r} has no genomes at selected threshold {selected_threshold}"
-            )
 
         n_samples = _require_integer(
             raw_unit.get("n_samples"),

--- a/metax/peptide_annotator/unit_specific_otf.py
+++ b/metax/peptide_annotator/unit_specific_otf.py
@@ -510,9 +510,6 @@ class ManifestOTFAnnotator:
         unit_output_records: list[dict],
         canonical_sample_cols: list[str],
     ) -> list[str]:
-        if not unit_output_records:
-            raise ValueError("No unit-specific OTF rows were produced")
-
         leading_cols = [
             "analysis_unit_id",
             "Sequence",
@@ -521,6 +518,9 @@ class ManifestOTFAnnotator:
             "Taxon",
             "Taxon_prop",
         ]
+        if not unit_output_records:
+            return leading_cols + canonical_sample_cols
+
         all_columns: list[str] = []
         for record in unit_output_records:
             for column in record["columns"]:
@@ -605,6 +605,12 @@ class ManifestOTFAnnotator:
             del unit_frame
             if record.get("temporary", False):
                 unit_path.unlink(missing_ok=True)
+        if not wrote_header:
+            pd.DataFrame(columns=ordered_columns).to_csv(
+                self.output_path,
+                sep="\t",
+                index=False,
+            )
         self._last_unique_sequences = (
             len(unique_sequences) if unique_sequences is not None else None
         )
@@ -1059,18 +1065,18 @@ class ManifestOTFAnnotator:
                     "message",
                 ],
             )
-            merged_columns, merged_rows = self._stream_merge_unit_outputs(
-                unit_output_records,
-                canonical_sample_cols,
-            )
-            unique_sequences = self._last_unique_sequences
-            unique_protein_groups = self._last_unique_protein_groups
             summary_path = self.artifacts_dir / "unit_annotation_summary.tsv"
             summary_df.to_csv(
                 summary_path,
                 sep="\t",
                 index=False,
             )
+            merged_columns, merged_rows = self._stream_merge_unit_outputs(
+                unit_output_records,
+                canonical_sample_cols,
+            )
+            unique_sequences = self._last_unique_sequences
+            unique_protein_groups = self._last_unique_protein_groups
             self._write_merged_info(
                 manifest=manifest,
                 manifest_samples=manifest_samples,

--- a/metax/peptide_annotator/unit_specific_otf.py
+++ b/metax/peptide_annotator/unit_specific_otf.py
@@ -236,9 +236,16 @@ class ManifestOTFAnnotator:
     def temporary_unit_otf_dir(self) -> Path:
         return self.artifacts_dir / "per_unit" / "unit_otf"
 
-    def _all_manifest_samples(self, manifest: GenomeSelectionManifest) -> list[str]:
+    def _manifest_samples(
+        self,
+        manifest: GenomeSelectionManifest,
+        *,
+        include_empty_genome_units: bool = True,
+    ) -> list[str]:
         samples: list[str] = []
         for unit in manifest.units.values():
+            if not include_empty_genome_units and not unit.genome_ids:
+                continue
             for sample in unit.sample_columns:
                 if sample not in samples:
                     samples.append(sample)
@@ -736,8 +743,12 @@ class ManifestOTFAnnotator:
             f"(genome threshold: {manifest.selected_genome_threshold}).",
             flush=True,
         )
-        manifest_samples = self._all_manifest_samples(manifest)
-        peptide_df = self._read_peptide_table(manifest_samples)
+        manifest_samples = self._manifest_samples(manifest)
+        required_manifest_samples = self._manifest_samples(
+            manifest,
+            include_empty_genome_units=False,
+        )
+        peptide_df = self._read_peptide_table(required_manifest_samples)
         if self.peptide_col not in peptide_df.columns:
             raise ValueError(f"Peptide column {self.peptide_col!r} not found in peptide table")
 
@@ -745,7 +756,7 @@ class ManifestOTFAnnotator:
         if sample_mapping is None:
             sample_mapping = self._resolve_sample_mapping(
                 peptide_df.columns,
-                manifest_samples,
+                required_manifest_samples,
             )
         mapped_input_cols = sorted(set(sample_mapping.values()))
         if mapped_input_cols:
@@ -756,7 +767,8 @@ class ManifestOTFAnnotator:
             )
         print(
             f"[Unit-specific] Sample mapping complete: {len(sample_mapping)} of "
-            f"{len(manifest_samples)} manifest samples mapped.",
+            f"{len(required_manifest_samples)} required manifest samples mapped "
+            f"({len(manifest_samples)} total).",
             flush=True,
         )
         global_genome_set = {

--- a/metax/peptide_annotator/unit_specific_otf.py
+++ b/metax/peptide_annotator/unit_specific_otf.py
@@ -715,6 +715,15 @@ class ManifestOTFAnnotator:
             genome_threshold=self.genome_threshold,
             strict=True,
         )
+        empty_genome_units = [
+            unit for unit in manifest.units.values() if not unit.genome_ids
+        ]
+        if empty_genome_units and self.on_empty_unit == "error":
+            unit = empty_genome_units[0]
+            raise ValueError(
+                f"Unit {unit.analysis_unit_id!r} has no genomes at selected threshold "
+                f"{manifest.selected_genome_threshold}"
+            )
         total_units = len(manifest.units)
         print(
             f"[Unit-specific] Preparing annotation for {total_units} units "
@@ -821,21 +830,42 @@ class ManifestOTFAnnotator:
         temporary_unit_dirs: list[Path] = []
         try:
             for unit_index, unit in enumerate(manifest.units.values(), start=1):
+                progress_prefix = (
+                    f"[Unit-specific] Unit {unit_index} of {total_units}: "
+                    f"{unit.analysis_unit_id}"
+                )
+                mapped_samples = [sample for sample in unit.sample_columns if sample in sample_mapping]
+                if not unit.genome_ids:
+                    message = (
+                        f"Unit {unit.analysis_unit_id!r} has no genomes at selected threshold "
+                        f"{manifest.selected_genome_threshold}"
+                    )
+                    warnings.warn(message, stacklevel=2)
+                    self._record_summary(
+                        summary_rows,
+                        unit.analysis_unit_id,
+                        len(unit.sample_columns),
+                        len(mapped_samples),
+                        len(peptide_df),
+                        0,
+                        0,
+                        0,
+                        "skipped",
+                        message,
+                    )
+                    print(f"{progress_prefix} skipped: {message}", flush=True)
+                    continue
+
                 tmpdir = _create_temporary_unit_directory(
                     self.temporary_unit_otf_dir,
                     unit.analysis_unit_id,
                 )
                 temporary_unit_dirs.append(tmpdir)
-                progress_prefix = (
-                    f"[Unit-specific] Unit {unit_index} of {total_units}: "
-                    f"{unit.analysis_unit_id}"
-                )
                 print(
                     f"{progress_prefix} started "
                     f"({len(unit.sample_columns)} samples, {len(unit.genome_ids)} genomes).",
                     flush=True,
                 )
-                mapped_samples = [sample for sample in unit.sample_columns if sample in sample_mapping]
                 try:
                     unit_df, _ = self._build_unit_dataframe(peptide_df, unit.sample_columns, sample_mapping)
                 except ValueError as exc:

--- a/tests/test_genome_selection_manifest.py
+++ b/tests/test_genome_selection_manifest.py
@@ -42,7 +42,7 @@ def test_manifest_rejects_duplicate_sample_assignments(tmp_path):
         load_genome_selection_manifest(path)
 
 
-def test_manifest_rejects_empty_unit_and_genome_threshold_contract(tmp_path):
+def test_manifest_rejects_empty_sample_unit_but_accepts_empty_genome_threshold(tmp_path):
     data = json.loads(FIXTURE.read_text(encoding="utf-8"))
     data["units"]["u1"]["sample_ids"] = []
     data["units"]["u1"]["n_samples"] = 0
@@ -52,11 +52,14 @@ def test_manifest_rejects_empty_unit_and_genome_threshold_contract(tmp_path):
         load_genome_selection_manifest(path)
 
     data = json.loads(FIXTURE.read_text(encoding="utf-8"))
-    data["units"]["u1"]["genome_ids_q005"] = []
     data["units"]["u1"]["genome_ids_q001"] = []
     path.write_text(json.dumps(data), encoding="utf-8")
-    with pytest.raises(ValueError, match="no genomes at selected threshold q0.05"):
-        load_genome_selection_manifest(path, genome_threshold="q0.05", strict=True)
+    manifest = load_genome_selection_manifest(
+        path,
+        genome_threshold="q0.01",
+        strict=True,
+    )
+    assert manifest.units["u1"].genome_ids == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_manifest_otf_backend.py
+++ b/tests/test_manifest_otf_backend.py
@@ -32,14 +32,14 @@ def test_digest_union_is_scanned_once(monkeypatch):
     assert calls[0]["selected_genomes_set"] == {"g1", "g2"}
 
 
-def test_run_warn_skips_empty_genome_unit_and_processes_other_units(tmp_path, monkeypatch):
+def test_run_warn_skips_empty_genome_unit_without_requiring_its_samples(tmp_path, monkeypatch):
     manifest_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
     manifest_data["units"]["u1"]["genome_ids_q001"] = []
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
     peptide_path = tmp_path / "peptides.tsv"
     peptide_path.write_text(
-        "Sequence\ts1\ts2\nPEP1\t1\t0\nPEP2\t0\t1\n",
+        "Sequence\ts2\nPEP1\t0\nPEP2\t1\n",
         encoding="utf-8",
     )
     taxafunc_db = tmp_path / "taxafunc.db"
@@ -84,6 +84,9 @@ def test_run_warn_skips_empty_genome_unit_and_processes_other_units(tmp_path, mo
     assert skipped["status"] == "skipped"
     assert skipped["n_genomes_from_manifest"] == 0
     assert "no genomes at selected threshold q0.01" in skipped["message"]
+    output = pd.read_csv(result.output_path, sep="\t")
+    assert "Intensity_s1" in output.columns
+    assert output["Intensity_s1"].isna().all()
 
 
 def test_run_warn_skips_all_empty_genome_units_and_writes_zero_row_outputs(tmp_path):
@@ -94,7 +97,7 @@ def test_run_warn_skips_all_empty_genome_units_and_writes_zero_row_outputs(tmp_p
     manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
     peptide_path = tmp_path / "peptides.tsv"
     peptide_path.write_text(
-        "Sequence\ts1\ts2\nPEP1\t1\t0\nPEP2\t0\t1\n",
+        "Sequence\nPEP1\nPEP2\n",
         encoding="utf-8",
     )
     taxafunc_db = tmp_path / "taxafunc.db"

--- a/tests/test_manifest_otf_backend.py
+++ b/tests/test_manifest_otf_backend.py
@@ -86,6 +86,63 @@ def test_run_warn_skips_empty_genome_unit_and_processes_other_units(tmp_path, mo
     assert "no genomes at selected threshold q0.01" in skipped["message"]
 
 
+def test_run_warn_skips_all_empty_genome_units_and_writes_zero_row_outputs(tmp_path):
+    manifest_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    for unit in manifest_data["units"].values():
+        unit["genome_ids_q001"] = []
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+    peptide_path = tmp_path / "peptides.tsv"
+    peptide_path.write_text(
+        "Sequence\ts1\ts2\nPEP1\t1\t0\nPEP2\t0\t1\n",
+        encoding="utf-8",
+    )
+    taxafunc_db = tmp_path / "taxafunc.db"
+    peptide_db = tmp_path / "peptide.db"
+    taxafunc_db.touch()
+    peptide_db.touch()
+    output_path = tmp_path / "output.tsv"
+    annotator = backend.ManifestOTFAnnotator(
+        peptide_table_path=str(peptide_path),
+        metaumbra_manifest_path=str(manifest_path),
+        taxafunc_anno_db_path=str(taxafunc_db),
+        output_path=str(output_path),
+        db_path=str(peptide_db),
+        genome_threshold="q0.01",
+        on_empty_unit="warn-skip",
+    )
+
+    with pytest.warns(UserWarning, match="has no genomes at selected threshold q0.01"):
+        result = annotator.run()
+
+    expected_columns = [
+        "analysis_unit_id",
+        "Sequence",
+        "Proteins",
+        "LCA_level",
+        "Taxon",
+        "Taxon_prop",
+        "Intensity_s1",
+        "Intensity_s2",
+    ]
+    assert result.rows == 0
+    assert result.column_names == expected_columns
+    assert result.column_count == len(expected_columns)
+    assert result.completed_units == 0
+    assert result.skipped_units == 2
+
+    output = pd.read_csv(result.output_path, sep="\t")
+    assert output.empty
+    assert output.columns.tolist() == expected_columns
+
+    summary = pd.read_csv(result.summary_path, sep="\t")
+    assert summary["analysis_unit_id"].tolist() == ["u1", "u2"]
+    assert summary["status"].tolist() == ["skipped", "skipped"]
+    assert summary["n_genomes_from_manifest"].tolist() == [0, 0]
+    assert Path(result.info_path).is_file()
+    assert (Path(result.summary_path).parent / "run_summary.json").is_file()
+
+
 def test_run_errors_on_empty_genome_unit_when_configured(tmp_path):
     manifest_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
     manifest_data["units"]["u1"]["genome_ids_q001"] = []

--- a/tests/test_manifest_otf_backend.py
+++ b/tests/test_manifest_otf_backend.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -29,6 +30,85 @@ def test_digest_union_is_scanned_once(monkeypatch):
     )
     assert len(calls) == 1
     assert calls[0]["selected_genomes_set"] == {"g1", "g2"}
+
+
+def test_run_warn_skips_empty_genome_unit_and_processes_other_units(tmp_path, monkeypatch):
+    manifest_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    manifest_data["units"]["u1"]["genome_ids_q001"] = []
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+    peptide_path = tmp_path / "peptides.tsv"
+    peptide_path.write_text(
+        "Sequence\ts1\ts2\nPEP1\t1\t0\nPEP2\t0\t1\n",
+        encoding="utf-8",
+    )
+    taxafunc_db = tmp_path / "taxafunc.db"
+    peptide_db = tmp_path / "peptide.db"
+    taxafunc_db.touch()
+    peptide_db.touch()
+
+    class FakeMapper:
+        def __init__(self, *, peptide_df, genome_list, **kwargs):
+            self.peptide_table = peptide_df
+            self.peptides_after_mapping = len(peptide_df)
+            self.final_peptide_table = peptide_df
+            self.selected_genomes_num = len(genome_list)
+
+        def all_in_one(self, **kwargs):
+            return pd.DataFrame(
+                {
+                    "Sequence": self.peptide_table["Sequence"],
+                    "Taxon": ["t__test"] * len(self.peptide_table),
+                    "Intensity_s2": self.peptide_table["Intensity_s2"],
+                }
+            )
+
+    monkeypatch.setattr(backend, "peptideProteinsMapper", FakeMapper)
+    annotator = backend.ManifestOTFAnnotator(
+        peptide_table_path=str(peptide_path),
+        metaumbra_manifest_path=str(manifest_path),
+        taxafunc_anno_db_path=str(taxafunc_db),
+        output_path=str(tmp_path / "output.tsv"),
+        db_path=str(peptide_db),
+        genome_threshold="q0.01",
+        on_empty_unit="warn-skip",
+    )
+
+    with pytest.warns(UserWarning, match="Unit 'u1' has no genomes"):
+        result = annotator.run()
+
+    assert result.completed_units == 1
+    assert result.skipped_units == 1
+    summary = pd.read_csv(result.summary_path, sep="\t")
+    skipped = summary.loc[summary["analysis_unit_id"] == "u1"].iloc[0]
+    assert skipped["status"] == "skipped"
+    assert skipped["n_genomes_from_manifest"] == 0
+    assert "no genomes at selected threshold q0.01" in skipped["message"]
+
+
+def test_run_errors_on_empty_genome_unit_when_configured(tmp_path):
+    manifest_data = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    manifest_data["units"]["u1"]["genome_ids_q001"] = []
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+    peptide_path = tmp_path / "peptides.tsv"
+    peptide_path.write_text("Sequence\ts1\ts2\nPEP\t1\t1\n", encoding="utf-8")
+    taxafunc_db = tmp_path / "taxafunc.db"
+    peptide_db = tmp_path / "peptide.db"
+    taxafunc_db.touch()
+    peptide_db.touch()
+    annotator = backend.ManifestOTFAnnotator(
+        peptide_table_path=str(peptide_path),
+        metaumbra_manifest_path=str(manifest_path),
+        taxafunc_anno_db_path=str(taxafunc_db),
+        output_path=str(tmp_path / "output.tsv"),
+        db_path=str(peptide_db),
+        genome_threshold="q0.01",
+        on_empty_unit="error",
+    )
+
+    with pytest.raises(ValueError, match="Unit 'u1' has no genomes at selected threshold q0.01"):
+        annotator.run()
 
 
 def test_merged_column_order_always_contains_analysis_unit_id(tmp_path):

--- a/tests/test_peptide_annotator_layout.py
+++ b/tests/test_peptide_annotator_layout.py
@@ -107,7 +107,7 @@ def test_manifest_gui_validation_respects_empty_genome_unit_policy(tmp_path):
     manifest_path = tmp_path / "genome_selection_manifest.json"
     manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
     peptide_path = tmp_path / "peptides.tsv"
-    peptide_path.write_text("Sequence\ts1\ts2\nPEP\t1\t1\n", encoding="utf-8")
+    peptide_path.write_text("Sequence\ts2\nPEP\t1\n", encoding="utf-8")
 
     warn_result = validate_genome_selection_manifest_for_gui(
         manifest_path=str(manifest_path),
@@ -123,6 +123,10 @@ def test_manifest_gui_validation_respects_empty_genome_unit_policy(tmp_path):
     )
 
     assert warn_result.ok
+    assert warn_result.manifest_samples == ["s1", "s2"]
+    assert warn_result.mapped_samples == {"s2": "s2"}
+    assert warn_result.missing_samples == []
+    assert "Required peptide table samples: 1" in warn_result.message
     assert "Empty genome units to skip: u1" in warn_result.message
     assert not error_result.ok
     assert "Unit 'u1' has no genomes at selected threshold q0.01" in error_result.message

--- a/tests/test_peptide_annotator_layout.py
+++ b/tests/test_peptide_annotator_layout.py
@@ -100,6 +100,34 @@ def test_manifest_gui_validation_accepts_diann_wide_matrix_compound_suffixes(tmp
     assert result.mapped_samples == dict(zip(samples, sample_columns))
 
 
+def test_manifest_gui_validation_respects_empty_genome_unit_policy(tmp_path):
+    fixture_path = Path(__file__).parent / "fixtures" / "genome_selection_manifest.v1.json"
+    manifest_data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    manifest_data["units"]["u1"]["genome_ids_q001"] = []
+    manifest_path = tmp_path / "genome_selection_manifest.json"
+    manifest_path.write_text(json.dumps(manifest_data), encoding="utf-8")
+    peptide_path = tmp_path / "peptides.tsv"
+    peptide_path.write_text("Sequence\ts1\ts2\nPEP\t1\t1\n", encoding="utf-8")
+
+    warn_result = validate_genome_selection_manifest_for_gui(
+        manifest_path=str(manifest_path),
+        peptide_table_path=str(peptide_path),
+        genome_threshold="q0.01",
+        on_empty_unit="warn-skip",
+    )
+    error_result = validate_genome_selection_manifest_for_gui(
+        manifest_path=str(manifest_path),
+        peptide_table_path=str(peptide_path),
+        genome_threshold="q0.01",
+        on_empty_unit="error",
+    )
+
+    assert warn_result.ok
+    assert "Empty genome units to skip: u1" in warn_result.message
+    assert not error_result.ok
+    assert "Unit 'u1' has no genomes at selected threshold q0.01" in error_result.message
+
+
 def test_annotation_layout_follows_source_input_output_order():
     app, window, ui = _build_layout_harness()
     try:


### PR DESCRIPTION
This pull request introduces improved handling and configurability for units with no genomes in the genome selection manifest across both the GUI and backend annotation pipeline. The main change is the addition of an `on_empty_unit` policy, allowing users to choose whether such units should cause an error or be skipped with a warning. The implementation ensures consistent enforcement and reporting of this policy in both the GUI and backend, and adds comprehensive tests for both behaviors.

**Policy and Validation Improvements:**

* Added an `on_empty_unit` parameter to `validate_genome_selection_manifest_for_gui`, with allowed values `"error"` or `"warn-skip"`, and enforced this contract in validation logic. If units with no genomes are found, the outcome depends on this policy: either return an error or include a warning in the summary. [[1]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R122) [[2]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R135-R142) [[3]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R160-R175) [[4]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R346-R350) [[5]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R364) [[6]](diffhunk://#diff-41324103d10f73b75679a0ed8057b3a435e2e05d85979c685a8e2f4b0dd66220R465)

**Backend Annotation Logic:**

* In `ManifestOTFAnnotator.run`, replaced the previous hard error on empty genome units with logic that raises an error or skips the unit and logs a warning, based on the `on_empty_unit` setting. Skipped units are recorded in the summary output. [[1]](diffhunk://#diff-4a2252582cded0cb15f1acbcd476757b5c07bf3981efac9719fe2d4baa018461R718-R726) [[2]](diffhunk://#diff-4a2252582cded0cb15f1acbcd476757b5c07bf3981efac9719fe2d4baa018461R833-L838)
* The manifest loader in `unit_specific_manifest.py` no longer raises an error for empty genome units, deferring the decision to the annotation or validation logic.

**Testing Enhancements:**

* Added new tests to cover both warning and error behaviors for empty genome units in the backend (`test_run_warn_skips_empty_genome_unit_and_processes_other_units`, `test_run_errors_on_empty_genome_unit_when_configured`).
* Added a GUI validation test to ensure the `on_empty_unit` policy is respected and messages are correct.
* Updated and clarified an existing manifest test to reflect the new contract for empty genome units. [[1]](diffhunk://#diff-eccb7660b45fe6cdc0443d20241a4ca90b4319a69ea7e0bbee7ac5e2f216bcf9L45-R45) [[2]](diffhunk://#diff-eccb7660b45fe6cdc0443d20241a4ca90b4319a69ea7e0bbee7ac5e2f216bcf9L55-R62)

These changes ensure users have clear, configurable control over how empty genome units are handled, with consistent behavior and feedback in both GUI and backend workflows.