### PR TITLE
feat: harden MetaX report contract

### DIFF
--- a/.github/workflows/installation-profiles.yml
+++ b/.github/workflows/installation-profiles.yml
@@ -25,6 +25,8 @@ jobs:
           METAX_METAUMBRA_SOURCE: ${{ github.workspace }}/MetaUmbra
         run: |
           python -c "import sys, metax, metax.cli.annotate, metax.cli.report; assert not any(name.startswith('PyQt') for name in sys.modules); assert 'metax.report' not in sys.modules"
+          python -m metax.cli.report --capabilities
+          python -c "import subprocess, sys; p = subprocess.run([sys.executable, '-m', 'metax.cli.report', '--otf', 'missing.tsv', '--out', 'report'], text=True, capture_output=True); assert p.returncode == 4; assert 'MetaXTools[report]' in p.stderr"
           python -m metax.cli.annotate --help
           python -m pytest tests/test_manifest_annotation_cli.py tests/test_annotation_subprocess_cleanup.py tests/test_pep_table_to_otf_dataframe.py tests/test_genome_selection_manifest.py tests/test_manifest_otf_backend.py tests/test_metaumbra_contract_integration.py -q
 
@@ -49,8 +51,9 @@ jobs:
         if: matrix.extra == 'report'
         run: |
           python -c "import metax.report; import sys; assert not any(name.startswith('PyQt') for name in sys.modules)"
+          python -m metax.cli.report --capabilities
           python -m metax.cli.report --help
-          python -m pytest tests/test_auto_report_config.py tests/test_auto_report_workflow.py tests/test_manifest_annotation_cli.py -q
+          python -m pytest tests/test_report_cli_contract.py tests/test_auto_report_config.py tests/test_auto_report_workflow.py -q
 
   gui-and-full-metadata:
     runs-on: ubuntu-latest
@@ -88,3 +91,19 @@ jobs:
           python -c "import sys, metax, metax.cli.annotate; assert not any(name.startswith('PyQt') for name in sys.modules)"
           python -m metax.cli.annotate --help
           python -m pytest tests/test_manifest_annotation_cli.py tests/test_annotation_subprocess_cleanup.py tests/test_pep_table_to_otf_dataframe.py tests/test_genome_selection_manifest.py tests/test_manifest_otf_backend.py -q
+
+  windows-report:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install ".[report]" pytest
+      - name: Verify Windows report contract
+        shell: pwsh
+        run: |
+          python -m metax.cli.report --capabilities
+          python -m metax.cli.report --help
+          python -m pytest tests/test_report_cli_contract.py -q

--- a/Docs/CLI.md
+++ b/Docs/CLI.md
@@ -13,7 +13,7 @@ Install MetaX into the Python environment from which the commands will be run.
 python -m pip install MetaXTools
 
 # Annotation plus the headless Auto OTF Report stack
-python -m pip install "MetaXTools[report]"
+python -m pip install "MetaXTools[report]>=2.6.2"
 
 # Desktop GUI and all optional analysis/report dependencies
 python -m pip install "MetaXTools[full]"
@@ -38,6 +38,15 @@ python -m metax.cli.report --help
 ```
 
 Using `python -m ...` guarantees that the command runs with the same interpreter that contains the selected MetaX installation.
+
+Workflow orchestrators can discover the report contract without loading Qt:
+
+```bash
+python -m metax.cli.report --capabilities
+```
+
+MetaXTools 2.6.2 reports workflow API `1.0` and result schema
+`metax.report_result.v1`.
 
 ## 3. Desktop Launcher
 
@@ -216,6 +225,24 @@ metax-report \
   --dpi 300
 ```
 
+For machine-to-machine execution, request the versioned result contract:
+
+```bash
+python -m metax.cli.report \
+  --otf OTF.tsv \
+  --meta metadata.tsv \
+  --out MetaX_Report \
+  --result-json metax_report_result.json
+```
+
+The atomically written JSON contains `schema_version`,
+`workflow_api_version`, `status`, `software`, absolute input and output
+paths, summary counts, structured warnings and errors, and runtime details.
+Completed runs use status `completed`; interrupted runs use `cancelled` and
+exit code `130`; failures use `failed` and a non-zero exit code. A completed
+result is not emitted unless the generated `index.html` exists and is
+non-empty.
+
 Without `--config`, `--otf` and `--out` are required. With a configuration file, command-line options override the corresponding configuration values.
 
 ### 5.1 Report Configuration File
@@ -276,6 +303,8 @@ metax-report --config report.yaml
 | `--run-network` | Enable heavier taxa-function network plots |
 | `--no-network` | Disable network plots |
 | `--overwrite` | Replace report files in a non-empty output directory |
+| `--result-json PATH` | Atomically write `metax.report_result.v1` for workflow orchestration |
+| `--capabilities` | Print the report capability contract and exit |
 
 The command prints the generated report `index.html` path on success and returns `0`. A report failure returns `1`; a missing optional report dependency returns `4`. The report directory also contains tables, figures, logs, `summary.json`, `config_used.yaml`, and reproducibility helpers.
 
@@ -329,6 +358,6 @@ Use `metax-report` when a standardized, unattended overview is sufficient. Use w
 - Examples use Bash line continuation (`\`). In PowerShell, replace each trailing backslash with a backtick or put the command on one line.
 - Quote paths containing spaces.
 - Prefer module invocation (`python -m metax.cli.annotate`) when the shell may resolve a command from the wrong Python environment.
-- Use annotation `--result-json` and process exit codes in workflow managers; do not determine success only by checking whether an output file exists.
+- Use annotation and report `--result-json` contracts plus process exit codes in workflow managers; do not determine success only by checking whether an output file exists.
 - Use a new report directory or pass `--overwrite` intentionally. MetaX rejects a non-empty report directory by default so unrelated runs are not mixed.
 - Run each command with `--help` to inspect the exact options supported by the installed MetaX version.

--- a/Docs/ChangeLog.md
+++ b/Docs/ChangeLog.md
@@ -4,7 +4,8 @@
 - New: Added a machine-readable automated-report CLI contract for workflow orchestrators.
 - New: Added report capability discovery and versioned `metax.report_result.v1` result JSON output.
 - Change: Report result files are written atomically and include generated artifacts, warnings, errors, and software provenance.
-- Test: Added report CLI capability, success-result, and failure-result contract coverage.
+- Change: Report result input/output paths are absolute, completed results require a non-empty `index.html`, and capability discovery remains available without loading the report or Qt stacks.
+- Test: Added report CLI capability, success, failure, cancellation, missing-artifact, real headless fixture, and Windows contract coverage.
 
 
 # Version: 2.6.1

--- a/README.md
+++ b/README.md
@@ -80,9 +80,13 @@ Show OTFS intensity in groups(samples), e.g., **Species-KO** OTF Heatmap
     >
     > ```bash
     > python -m pip install "MetaXTools[analyzer]"
-    > python -m pip install "MetaXTools[report]"
-    > metax-report --config report.yaml
+    > python -m pip install "MetaXTools[report]>=2.6.2"
+    > python -m metax.cli.report --capabilities
+    > metax-report --config report.yaml --result-json metax_report_result.json
     > ```
+
+    > MetaXTools 2.6.2 provides the machine-readable
+    > `metax.report_result.v1` contract for headless workflow orchestration.
 
 - **Desktop GUI / complete installation**
 

--- a/README_PyPi.md
+++ b/README_PyPi.md
@@ -80,9 +80,13 @@ Show OTFS intensity in groups(samples), e.g., **Species-KO** OTF Heatmap
     >
     > ```bash
     > python -m pip install "MetaXTools[analyzer]"
-    > python -m pip install "MetaXTools[report]"
-    > metax-report --config report.yaml
+    > python -m pip install "MetaXTools[report]>=2.6.2"
+    > python -m metax.cli.report --capabilities
+    > metax-report --config report.yaml --result-json metax_report_result.json
     > ```
+
+    > MetaXTools 2.6.2 provides the machine-readable
+    > `metax.report_result.v1` contract for headless workflow orchestration.
 
 - **Desktop GUI / complete installation**
 

--- a/metax/cli/report.py
+++ b/metax/cli/report.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
+
+from metax.utils.version import __version__
 
 
 REPORT_EXTRA = "MetaXTools[report]"
@@ -20,6 +23,9 @@ REPORT_IMPORT_ROOTS = {
     "statsmodels",
     "upsetplot",
 }
+REPORT_WORKFLOW_API_VERSION = "1.0"
+REPORT_RESULT_SCHEMA_VERSION = "metax.report_result.v1"
+REPORT_CAPABILITIES_SCHEMA_VERSION = "metax.report_capabilities.v1"
 
 
 def _missing_report_message(missing_module: str | None = None) -> str:
@@ -32,6 +38,21 @@ def _missing_report_message(missing_module: str | None = None) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     """Load the report CLI only when the headless analysis stack is installed."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if arguments == ["--capabilities"]:
+        print(
+            json.dumps(
+                {
+                    "schema_version": REPORT_CAPABILITIES_SCHEMA_VERSION,
+                    "available": True,
+                    "metax_version": __version__,
+                    "workflow_api_version": REPORT_WORKFLOW_API_VERSION,
+                    "result_schema_version": REPORT_RESULT_SCHEMA_VERSION,
+                },
+                indent=2,
+            )
+        )
+        return 0
     try:
         report_cli = importlib.import_module("metax.report.cli")
     except ModuleNotFoundError as exc:
@@ -40,7 +61,7 @@ def main(argv: list[str] | None = None) -> int:
             print(_missing_report_message(exc.name), file=sys.stderr)
             return 4
         raise
-    return report_cli.main(argv)
+    return report_cli.main(arguments)
 
 
 if __name__ == "__main__":

--- a/metax/report/cli.py
+++ b/metax/report/cli.py
@@ -138,12 +138,17 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _success_result(config: AutoReportConfig, result: Any) -> dict[str, Any]:
+    index_html = Path(result.index_html_path).expanduser().resolve()
+    if not index_html.is_file() or index_html.stat().st_size == 0:
+        raise RuntimeError(
+            f"Report backend did not produce a non-empty index.html: {index_html}"
+        )
     registry = result.registry.to_dict()
     return {
         **_terminal_result("completed", config),
         "outputs": {
             "output_directory": str(Path(result.output_dir).resolve()),
-            "index_html": str(Path(result.index_html_path).resolve()),
+            "index_html": str(index_html),
             "summary_json": str(Path(result.summary_json_path).resolve()),
             "reproducibility_artifacts": {
                 key: str(Path(path).resolve())
@@ -168,14 +173,16 @@ def _terminal_result(
     *,
     error: str = "",
 ) -> dict[str, Any]:
+    otf_path = _absolute_path(config.input.otf_path) if config else None
+    metadata_path = _absolute_path(config.input.meta_path) if config else None
     return {
         "schema_version": REPORT_RESULT_SCHEMA_VERSION,
         "workflow_api_version": REPORT_WORKFLOW_API_VERSION,
         "status": status,
         "software": {"metax_version": __version__},
         "inputs": {
-            "otf_table": config.input.otf_path if config else None,
-            "metadata_table": config.input.meta_path if config else None,
+            "otf_table": otf_path,
+            "metadata_table": metadata_path,
         },
         "outputs": {},
         "summary": {},
@@ -191,8 +198,17 @@ def _write_result_json(path: str | None, payload: dict[str, Any]) -> None:
     output_path = Path(path).expanduser().resolve()
     output_path.parent.mkdir(parents=True, exist_ok=True)
     temporary_path = output_path.with_suffix(output_path.suffix + ".tmp")
-    temporary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    temporary_path.replace(output_path)
+    try:
+        temporary_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        temporary_path.replace(output_path)
+    finally:
+        temporary_path.unlink(missing_ok=True)
+
+
+def _absolute_path(path: str | None) -> str | None:
+    if not path:
+        return None
+    return str(Path(path).expanduser().resolve())
 
 
 def _split_csv(value: str) -> list[str]:

--- a/tests/fixtures/report_contract/OTF.tsv
+++ b/tests/fixtures/report_contract/OTF.tsv
@@ -1,0 +1,7 @@
+Sequence	Proteins	LCA_level	Taxon	Taxon_prop	Gene	Gene_prop	Intensity_S1	Intensity_S2	Intensity_S3	Intensity_S4
+PEPTIDEAA	P001	species	d__Bacteria|p__Firmicutes|g__Lactobacillus|s__Lactobacillus acidophilus	1.0	geneA	1.0	100	120	20	25
+PEPTIDEBB	P002	species	d__Bacteria|p__Firmicutes|g__Lactobacillus|s__Lactobacillus acidophilus	1.0	geneA	1.0	80	90	10	15
+PEPTIDECC	P003	species	d__Bacteria|p__Bacteroidota|g__Bacteroides|s__Bacteroides fragilis	1.0	geneB	1.0	20	25	110	120
+PEPTIDEDD	P004	species	d__Bacteria|p__Bacteroidota|g__Bacteroides|s__Bacteroides fragilis	1.0	geneB	1.0	15	10	90	100
+PEPTIDEEE	P005	species	d__Bacteria|p__Actinobacteriota|g__Bifidobacterium|s__Bifidobacterium longum	1.0	geneC	1.0	30	35	40	45
+PEPTIDEFF	P006	species	d__Bacteria|p__Actinobacteriota|g__Bifidobacterium|s__Bifidobacterium longum	1.0	geneC	1.0	25	30	35	40

--- a/tests/fixtures/report_contract/config.yaml
+++ b/tests/fixtures/report_contract/config.yaml
@@ -1,0 +1,40 @@
+analysis:
+  group_meta: Group
+  control_group: control
+preprocessing:
+  taxa_peptide_num_threshold: 1
+  func_peptide_num_threshold: 1
+  otf_peptide_num_threshold: 1
+tables:
+  taxa_levels:
+    - s
+  function_columns:
+    - Gene
+statistics:
+  run_anova: false
+  run_ttest: false
+  run_group_vs_control: false
+plots:
+  top_n: 5
+  run_overview: true
+  run_pca: false
+  run_pca_3d: false
+  run_tsne: false
+  run_correlation: false
+  run_heatmap: false
+  run_box: false
+  run_bar: false
+  run_barplot: false
+  run_upset: false
+  run_alpha_diversity: false
+  run_beta_diversity: false
+  run_diversity: false
+  run_volcano: false
+  run_sankey: false
+  run_sunburst: false
+  run_treemap: false
+  run_network: false
+report:
+  overwrite: true
+  figure_formats:
+    - png

--- a/tests/fixtures/report_contract/metadata.tsv
+++ b/tests/fixtures/report_contract/metadata.tsv
@@ -1,0 +1,5 @@
+Sample	Group
+S1	control
+S2	control
+S3	treatment
+S4	treatment

--- a/tests/test_report_cli_contract.py
+++ b/tests/test_report_cli_contract.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -70,6 +72,7 @@ def test_report_result_json_contract(tmp_path: Path, monkeypatch) -> None:
     assert payload["schema_version"] == "metax.report_result.v1"
     assert payload["workflow_api_version"] == "1.0"
     assert payload["status"] == "completed"
+    assert payload["inputs"]["otf_table"] == str(otf_path.resolve())
     assert payload["outputs"]["index_html"] == str((output_dir / "index.html").resolve())
     assert payload["summary"] == {
         "tables": 1,
@@ -78,6 +81,43 @@ def test_report_result_json_contract(tmp_path: Path, monkeypatch) -> None:
         "interactive_html": 0,
     }
     assert payload["warnings"][0]["message"] == "A test warning"
+
+
+def test_report_rejects_missing_index_html(tmp_path: Path, monkeypatch) -> None:
+    otf_path = tmp_path / "OTF.tsv"
+    otf_path.write_text("Sequence\tIntensity_A\nPEPTIDE\t1\n", encoding="utf-8")
+    result_json = tmp_path / "failed.json"
+    output_dir = tmp_path / "report"
+
+    class IncompleteReport:
+        def __init__(self, config) -> None:
+            self.config = config
+
+        def run(self):
+            output_dir.mkdir()
+            return SimpleNamespace(
+                output_dir=output_dir,
+                index_html_path=output_dir / "index.html",
+                summary_json_path=output_dir / "summary.json",
+                registry=ResultRegistry(),
+                reproducibility_artifacts={},
+            )
+
+    monkeypatch.setattr(cli, "AutoOTFReport", IncompleteReport)
+
+    assert cli.main(
+        [
+            "--otf",
+            str(otf_path),
+            "--out",
+            str(output_dir),
+            "--result-json",
+            str(result_json),
+        ]
+    ) == 1
+    payload = json.loads(result_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "failed"
+    assert "non-empty index.html" in payload["errors"][0]["message"]
 
 
 def test_report_failure_writes_machine_readable_result(tmp_path: Path, monkeypatch) -> None:
@@ -109,3 +149,76 @@ def test_report_failure_writes_machine_readable_result(tmp_path: Path, monkeypat
     payload = json.loads(result_json.read_text(encoding="utf-8"))
     assert payload["status"] == "failed"
     assert payload["errors"] == [{"message": "analysis failed", "source": "metax-report"}]
+
+
+def test_report_cancellation_contract(tmp_path: Path, monkeypatch) -> None:
+    otf_path = tmp_path / "OTF.tsv"
+    otf_path.write_text("Sequence\tIntensity_A\nPEPTIDE\t1\n", encoding="utf-8")
+    result_json = tmp_path / "cancelled.json"
+
+    class CancelledReport:
+        def __init__(self, config) -> None:
+            self.config = config
+
+        def run(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli, "AutoOTFReport", CancelledReport)
+    assert cli.main(
+        [
+            "--otf",
+            str(otf_path),
+            "--out",
+            str(tmp_path / "report"),
+            "--result-json",
+            str(result_json),
+        ]
+    ) == 130
+    payload = json.loads(result_json.read_text(encoding="utf-8"))
+    assert payload["status"] == "cancelled"
+    assert payload["errors"][0]["source"] == "metax-report"
+
+
+def test_real_report_cli_contract(tmp_path: Path) -> None:
+    fixture_dir = Path(__file__).parent / "fixtures" / "report_contract"
+    output_dir = tmp_path / "report output with spaces"
+    result_json = tmp_path / "result output" / "metax_report_result.json"
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "metax.cli.report",
+            "--config",
+            str(fixture_dir / "config.yaml"),
+            "--otf",
+            str(fixture_dir / "OTF.tsv"),
+            "--meta",
+            str(fixture_dir / "metadata.tsv"),
+            "--out",
+            str(output_dir),
+            "--result-json",
+            str(result_json),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(result_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "metax.report_result.v1"
+    assert payload["workflow_api_version"].split(".", 1)[0] == "1"
+    assert payload["status"] == "completed"
+    assert Path(payload["outputs"]["index_html"]).stat().st_size > 0
+    assert Path(payload["outputs"]["summary_json"]).is_file()
+    assert payload["summary"]["tables"] + payload["summary"]["figures"] >= 1
+    assert isinstance(payload["warnings"], list)
+    assert isinstance(payload["errors"], list)
+    for path in [
+        payload["inputs"]["otf_table"],
+        payload["inputs"]["metadata_table"],
+        payload["outputs"]["output_directory"],
+        payload["outputs"]["index_html"],
+        payload["outputs"]["summary_json"],
+    ]:
+        assert Path(path).is_absolute()


### PR DESCRIPTION
## Summary
- harden `python -m metax.cli.report` as a headless machine-readable contract
- add realistic OTF/metadata/config fixtures and subprocess coverage for success, failure, cancellation, paths with spaces, and atomic result output
- expand Linux/Windows installation-profile CI and document the 2.6.2 report contract and install hint

## Validation
- `pytest -q tests/test_report_cli_contract.py`: 6 passed
- Ruff checks: passed
- full MetaX suite was attempted with a 6-minute bound but did not complete, so it is not reported as passing

## Release sequencing
This PR targets `dev`. After it merges and CI is green, publish MetaXTools 2.6.2 and verify PyPI before opening the separate `dev -> main` release PR.